### PR TITLE
Jakarta Persistence Driver - deleteAll, add implicit parts of a JDQL SELECT query (1.1.x)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ test-output/
 .settings/
 **/.DS_Store
 /.quarkus/
+nbproject/

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/DeleteQueryParser.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/DeleteQueryParser.java
@@ -54,7 +54,10 @@ class DeleteQueryParser extends BaseUpdateQueryParser {
     }
 
     <T> long deleteAll(Class<T> type) {
-        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+        CriteriaBuilder criteriaBuilder = entityManager().getCriteriaBuilder();
+        CriteriaDelete<T> deleteCriteria = criteriaBuilder.createCriteriaDelete(type);
+        long entries = entityManager().createQuery(deleteCriteria).executeUpdate();
+        return entries;
     }
 
     long delete(DeleteQuery deleteQuery) {

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/QLUtil.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/QLUtil.java
@@ -20,16 +20,18 @@ package org.eclipse.jnosql.jakartapersistence.mapping;
  * @author Ondro Mihalyi
  */
 final class QLUtil {
+    private static final String UPDATE_KEYWORD = "UPDATE";
+    private static final String DELETE_KEYWORD = "DELETE";
 
     private QLUtil() {
     }
 
     static boolean isUpdateQuery(String query) {
-        return queryStartsWith(query, "UPDATE", 6);
+        return queryStartsWith(query, UPDATE_KEYWORD, UPDATE_KEYWORD.length());
     }
 
     static boolean isDeleteQuery(String query) {
-        return queryStartsWith(query, "DELETE", 6);
+        return queryStartsWith(query, DELETE_KEYWORD, DELETE_KEYWORD.length());
     }
 
     static boolean queryStartsWith(String query, String word, int lengthOfWord) {

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/SelectQueryParser.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/SelectQueryParser.java
@@ -42,6 +42,7 @@ import org.eclipse.jnosql.jakartapersistence.communication.PersistenceDatabaseMa
 import org.eclipse.jnosql.jakartapersistence.mapping.core.PersistencePage;
 
 import static org.eclipse.jnosql.jakartapersistence.mapping.BaseQueryParser.parseCriteria;
+import org.eclipse.jnosql.jakartapersistence.mapping.parser.OptionalPartsParser;
 
 class SelectQueryParser extends BaseQueryParser {
 
@@ -233,10 +234,7 @@ class SelectQueryParser extends BaseQueryParser {
 
     @Override
     protected String preProcessQuery(String queryString, String entity) {
-        if (queryString.startsWith("WHERE") && entity != null) {
-            queryString = "SELECT this FROM " + entity + " " + queryString;
-        }
-        return queryString;
+        return new OptionalPartsParser(queryString, entity).getCompleteSelect();
     }
 
     private <FROM, RESULT> TypedQuery<RESULT> buildQuery(Class<FROM> fromType, Class<RESULT> resultType,

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/parser/OptionalPartsParser.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/parser/OptionalPartsParser.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ *
+ *  Contributors:
+ *
+ *  Petr Aubrecht
+ */
+package org.eclipse.jnosql.jakartapersistence.mapping.parser;
+
+/**
+ * Parse the beginning of the SELECT command, fill the optional parts and return
+ * complete query.
+ *
+ * @author Petr Aubrecht
+ */
+public class OptionalPartsParser {
+
+    private static final String SELECT = "SELECT";
+    private static final String COUNT = "COUNT";
+    private static final String THIS = "THIS";
+    private static final String DOT = ".";
+    private static final String FROM = "FROM";
+    private static final String OPEN_PARENTHESIS = "(";
+    private static final String CLOSE_PARENTHESIS = ")";
+
+    private String queryString;
+    private String entity;
+    private int position = 0;
+    private StringBuilder updatedQueryString = new StringBuilder();
+
+    public OptionalPartsParser(String queryString, String entity) {
+        this.queryString = queryString;
+        this.entity = entity;
+        selectStatement();
+    }
+
+    public String getCompleteSelect() {
+        return updatedQueryString.toString().stripTrailing();
+    }
+
+    /**
+     * select_statement : select_clause? from_clause? where_clause?
+     * orderby_clause?;
+     */
+    private void selectStatement() {
+        skipOpionalSpace();
+        if (startsWith(SELECT)) {
+            selectClause();
+        } else {
+            updatedQueryString.append(SELECT + " this");
+        }
+        skipSpace();
+        if (startsWith(FROM)) {
+            fromClause();
+        } else {
+            updatedQueryString.append(FROM + " " + entity);
+        }
+        skipSpace();
+        // do not care about the rest
+        copyRest();
+    }
+
+    /**
+     * select_clause : 'SELECT' select_list;
+     */
+    private void selectClause() {
+        skip(SELECT);
+        selectList();
+    }
+
+    /**
+     * from_clause : 'FROM' entity_name;
+     */
+    private void fromClause() {
+        skip(FROM);
+        skipSpace();
+        identifier(); // entity_name : identifier
+    }
+
+    /**
+     * Copy the remaining part of the SELECT command.
+     */
+    private void copyRest() {
+        updatedQueryString.append(queryString.substring(position));
+    }
+
+    /**
+     * select_list : state_field_path_expression | aggregate_expression;
+     */
+    private void selectList() {
+        skipSpace();
+        if (startsWith(COUNT)) {
+            aggregateExpression();
+        } else {
+            stateFieldPathExpression();
+        }
+    }
+
+    /**
+     * aggregate_expression : 'COUNT' '(' 'THIS' ')';
+     */
+    private void aggregateExpression() {
+        skip(COUNT);
+        skipOpionalSpace();
+        testAndskip(OPEN_PARENTHESIS);
+        skipOpionalSpace();
+        testAndskip(THIS);
+        skipOpionalSpace();
+        testAndskip(CLOSE_PARENTHESIS);
+    }
+
+    /**
+     * state_field_path_expression : IDENTIFIER ('.' IDENTIFIER)*;
+     */
+    private void stateFieldPathExpression() {
+        identifier();
+        skipOpionalSpace();
+        while (startsWith(DOT)) {
+            skip(DOT);
+            skipOpionalSpace();
+            identifier();
+            skipOpionalSpace();
+        }
+    }
+
+    /**
+     * Identifier is any Java identifier
+     */
+    private void identifier() {
+//        skipOpionalSpace();
+        if (position >= queryString.length() || !Character.isJavaIdentifierStart(queryString.charAt(position))) {
+            throw new IllegalArgumentException("Expected identifier at position " + position);
+        }
+        int start = position;
+        position++;
+        while (position < queryString.length() && Character.isJavaIdentifierPart(queryString.charAt(position))) {
+            position++;
+        }
+
+        updatedQueryString.append(queryString.substring(start, position));
+    }
+
+    private boolean startsWith(String terminal) {
+        return position + terminal.length() <= queryString.length()
+                && queryString.substring(position, position + terminal.length()).equalsIgnoreCase(terminal);
+    }
+
+    private void skip(String terminal) {
+        updatedQueryString.append(terminal);
+        position += terminal.length();
+    }
+
+    private void testAndskip(String terminal) {
+        if (!startsWith(terminal)) {
+            throw new IllegalArgumentException("Expected " + terminal + " at position " + position);
+        }
+        skip(terminal);
+    }
+
+    private void skipOpionalSpace() {
+        while (position < queryString.length() && Character.isWhitespace(queryString.charAt(position))) {
+            position++;
+        }
+    }
+
+    private void skipSpace() {
+        skipOpionalSpace();
+        // replace all spaces with one space
+        updatedQueryString.append(" ");
+    }
+
+}

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/jakartapersistence/mapping/parser/OptionalPartsParserTest.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/jakartapersistence/mapping/parser/OptionalPartsParserTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ *
+ *  Contributors:
+ *
+ *  Petr Aubrecht
+ */
+package org.eclipse.jnosql.jakartapersistence.mapping.parser;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test adding missing parts in SELECT.
+ *
+ * @author Petr Aubrecht
+ */
+public class OptionalPartsParserTest {
+
+    /**
+     * Test empty select.
+     */
+    @Test
+    public void testEmptySelect() {
+        OptionalPartsParser parser = new OptionalPartsParser("", "Person");
+        String complete = parser.getCompleteSelect();
+        assertEquals("SELECT this FROM Person", complete, "Empty select should select all people, filling both SELECT and FROM");
+    }
+
+    /**
+     * Test missing select, but with FROM.
+     */
+    @Test
+    public void testMissingSelect() {
+        OptionalPartsParser parser = new OptionalPartsParser("FROM Person", "Person");
+        String complete = parser.getCompleteSelect();
+        assertEquals("SELECT this FROM Person", complete, "Missing select should be added, keeps FROM");
+    }
+
+    /**
+     * Test missing FROM, but with SELECT.
+     */
+    @Test
+    public void testMissingFrom() {
+        OptionalPartsParser parser = new OptionalPartsParser("SELECT this.name", "Person");
+        String complete = parser.getCompleteSelect();
+        assertEquals("SELECT this.name FROM Person", complete, "Missing select should be added, keeps FROM");
+    }
+
+    // TODO test COUNT
+    // TODO test WHERE
+    // TODO test spaces everywhere
+}


### PR DESCRIPTION
A follow-up to https://github.com/eclipse-jnosql/jnosql-extensions/pull/151.

* deleteAll method support
* add implicit JDQL SELECT query parts which are required by JPQL

Passes 57 tests out of 84 standalone Data 1.0 TCK tests

Submitting on behalf of @aubi, who is an Eclipse Foundation contributor and agreed to contribute this code to the JNoSQL project.
