### PR TITLE
Jakarta Persistence Driver -  Contains, StartsWith, EndsWith, Exists, Or, OrderBy, IgnoreCase (1.1.x)

### DIFF
--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/src/test/java/org/eclipse/jnosql/tck/jakartapersistence/JNoSqlPersistenceEntityTests.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/src/test/java/org/eclipse/jnosql/tck/jakartapersistence/JNoSqlPersistenceEntityTests.java
@@ -15,7 +15,6 @@
 package org.eclipse.jnosql.tck.jakartapersistence;
 
 import ee.jakarta.tck.data.standalone.persistence.PersistenceEntityTests;
-
 import org.eclipse.jnosql.jakartapersistence.communication.PersistenceDatabaseManager;
 import org.eclipse.jnosql.jakartapersistence.mapping.PersistenceDocumentTemplate;
 import org.eclipse.jnosql.jakartapersistence.mapping.spi.JakartaPersistenceExtension;
@@ -29,7 +28,6 @@ import org.jboss.weld.junit5.auto.AddExtensions;
 import org.jboss.weld.junit5.auto.AddPackages;
 import org.jboss.weld.junit5.auto.EnableAutoWeld;
 import org.junit.jupiter.api.Disabled;
-
 import org.junit.jupiter.api.extension.ExtendWith;
 
 
@@ -44,13 +42,23 @@ import org.junit.jupiter.api.extension.ExtendWith;
 public class JNoSqlPersistenceEntityTests extends PersistenceEntityTests {
 
     /**
-     * This test expects running outside of a global transaction. It should be executed
-     * in {@link JNoSqlPersistenceEntityTestsNoGlobalTx}
+     * This test expects running outside of a global transaction. It should be
+     * executed in {@link JNoSqlPersistenceEntityTestsNoGlobalTx}
      */
     @Override
     @Disabled
     public void testVersionedInsertUpdateDelete() {
         super.testVersionedInsertUpdateDelete();
+    }
+
+    /**
+     * This test expects running outside of a global transaction. It should be
+     * executed in {@link JNoSqlPersistenceEntityTestsNoGlobalTx}
+     */
+    @Override
+    @Disabled
+    public void testMultipleInsertUpdateDelete() {
+        super.testMultipleInsertUpdateDelete();
     }
 
 }

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/src/test/java/org/eclipse/jnosql/tck/jakartapersistence/JNoSqlPersistenceEntityTests.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/src/test/java/org/eclipse/jnosql/tck/jakartapersistence/JNoSqlPersistenceEntityTests.java
@@ -28,6 +28,7 @@ import org.eclipse.jnosql.mapping.semistructured.EntityConverter;
 import org.jboss.weld.junit5.auto.AddExtensions;
 import org.jboss.weld.junit5.auto.AddPackages;
 import org.jboss.weld.junit5.auto.EnableAutoWeld;
+import org.junit.jupiter.api.Disabled;
 
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -41,5 +42,15 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @AddPackages({JNoSqlPersistenceEntityTests.class, PersistenceEntityTests.class})
 @ExtendWith(TransactionExtension.class)
 public class JNoSqlPersistenceEntityTests extends PersistenceEntityTests {
+
+    /**
+     * This test expects running outside of a global transaction. It should be executed
+     * in {@link JNoSqlPersistenceEntityTestsNoGlobalTx}
+     */
+    @Override
+    @Disabled
+    public void testVersionedInsertUpdateDelete() {
+        super.testVersionedInsertUpdateDelete();
+    }
 
 }

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/src/test/java/org/eclipse/jnosql/tck/jakartapersistence/JNoSqlPersistenceEntityTestsNoGlobalTx.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/src/test/java/org/eclipse/jnosql/tck/jakartapersistence/JNoSqlPersistenceEntityTestsNoGlobalTx.java
@@ -1,0 +1,66 @@
+/*
+ *  Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Ondro Mihalyi
+ */
+package org.eclipse.jnosql.tck.jakartapersistence;
+
+import ee.jakarta.tck.data.standalone.persistence.PersistenceEntityTests;
+
+import org.eclipse.jnosql.mapping.core.Converters;
+import org.eclipse.jnosql.mapping.document.DocumentTemplate;
+import org.eclipse.jnosql.mapping.document.DocumentTemplateProducer;
+import org.eclipse.jnosql.mapping.reflection.Reflections;
+import org.eclipse.jnosql.mapping.semistructured.EntityConverter;
+import org.jboss.weld.junit5.auto.AddExtensions;
+import org.jboss.weld.junit5.auto.AddPackages;
+import org.jboss.weld.junit5.auto.EnableAutoWeld;
+
+
+
+import org.eclipse.jnosql.jakartapersistence.communication.PersistenceDatabaseManager;
+import org.eclipse.jnosql.jakartapersistence.mapping.PersistenceDocumentTemplate;
+import org.eclipse.jnosql.jakartapersistence.mapping.spi.JakartaPersistenceExtension;
+import org.eclipse.jnosql.mapping.reflection.spi.ReflectionEntityMetadataExtension;
+import org.eclipse.jnosql.tck.jakartapersistence.junit.RunOnly;
+import org.eclipse.jnosql.tck.jakartapersistence.junit.RunOnlyCondition;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import ee.jakarta.tck.data.standalone.entity.EntityTests;
+
+/**
+ * This is a group of PersistenceEntityTests tests that must run outside of a global transaction,
+ * otherwise the test scenario doesn't make sense and would always fail. The rest of the tests
+ * are executed in {@link JNoSqlPersistenceEntityTests}, with global transactions created with
+ * {@link TransactionExtension}
+ *
+ * @author ondro
+ */
+@EnableAutoWeld
+@AddPackages(value = {Converters.class, EntityConverter.class, DocumentTemplate.class})
+@AddPackages(value = DocumentTemplateProducer.class)
+@AddPackages(value = Reflections.class)
+@AddExtensions(value = {ReflectionEntityMetadataExtension.class, JakartaPersistenceExtension.class})
+@AddPackages(value = {PersistenceDocumentTemplate.class, PersistenceDatabaseManager.class})
+@AddPackages(value = {JNoSqlPersistenceEntityTestsNoGlobalTx.class, EntityTests.class})
+@ExtendWith(RunOnlyCondition.class)
+public class JNoSqlPersistenceEntityTestsNoGlobalTx extends PersistenceEntityTests {
+
+    @Override
+    @RunOnly
+    @Test
+    public void testVersionedInsertUpdateDelete() {
+        super.testVersionedInsertUpdateDelete();
+    }
+
+}

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/src/test/java/org/eclipse/jnosql/tck/jakartapersistence/JNoSqlPersistenceEntityTestsNoGlobalTx.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/src/test/java/org/eclipse/jnosql/tck/jakartapersistence/JNoSqlPersistenceEntityTestsNoGlobalTx.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
  *   are made available under the terms of the Eclipse Public License v1.0
  *   and Apache License v2.0 which accompanies this distribution.

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/src/test/java/org/eclipse/jnosql/tck/jakartapersistence/JNoSqlPersistenceEntityTestsNoGlobalTx.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/src/test/java/org/eclipse/jnosql/tck/jakartapersistence/JNoSqlPersistenceEntityTestsNoGlobalTx.java
@@ -63,4 +63,11 @@ public class JNoSqlPersistenceEntityTestsNoGlobalTx extends PersistenceEntityTes
         super.testVersionedInsertUpdateDelete();
     }
 
+    @Override
+    @RunOnly
+    @Test
+    public void testMultipleInsertUpdateDelete() {
+        super.testMultipleInsertUpdateDelete();
+    }
+
 }

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/src/test/java/org/eclipse/jnosql/tck/jakartapersistence/junit/RunOnly.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/src/test/java/org/eclipse/jnosql/tck/jakartapersistence/junit/RunOnly.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License v1.0

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/src/test/java/org/eclipse/jnosql/tck/jakartapersistence/junit/RunOnly.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/src/test/java/org/eclipse/jnosql/tck/jakartapersistence/junit/RunOnly.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ *
+ *  Contributors:
+ *
+ *  Ondro Mihalyi
+ */
+package org.eclipse.jnosql.tck.jakartapersistence.junit;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ *
+ * @author Ondro Mihalyi
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface RunOnly {}
+

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/src/test/java/org/eclipse/jnosql/tck/jakartapersistence/junit/RunOnlyCondition.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/src/test/java/org/eclipse/jnosql/tck/jakartapersistence/junit/RunOnlyCondition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License v1.0

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/src/test/java/org/eclipse/jnosql/tck/jakartapersistence/junit/RunOnlyCondition.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/src/test/java/org/eclipse/jnosql/tck/jakartapersistence/junit/RunOnlyCondition.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ *
+ *  Contributors:
+ *
+ *  Ondro Mihalyi
+ */
+package org.eclipse.jnosql.tck.jakartapersistence.junit;
+
+import java.lang.reflect.Method;
+import java.util.Optional;
+
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+/**
+ *
+ * @author Ondro Mihalyi
+ */
+public class RunOnlyCondition implements ExecutionCondition {
+
+    @Override
+    public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+        Optional<Method> method = context.getTestMethod();
+        if (method.isPresent()) {
+            boolean hasRunOnly = method.map(m -> m.isAnnotationPresent(RunOnly.class)).orElse(false);
+
+            if (!hasRunOnly) {
+                return ConditionEvaluationResult.disabled("Disabled: not marked with @RunOnly");
+            }
+        }
+
+        return ConditionEvaluationResult.enabled("Enabled");
+    }
+}

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/src/test/resources/META-INF/persistence.xml
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/src/test/resources/META-INF/persistence.xml
@@ -36,6 +36,7 @@
       <property name="jakarta.persistence.jdbc.user" value="APP"/>
       <property name="jakarta.persistence.jdbc.password" value="APP"/>
       <!-- EclipseLink specific properties -->
+      <property name="eclipselink.orm.throw.exceptions" value="true"/>
       <property name="eclipselink.target-database" value="Derby"/>
       <property name="eclipselink.ddl-generation" value="drop-and-create-tables"/>
       <property name="eclipselink.debug" value="ALL"/>

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/src/test/resources/META-INF/persistence.xml
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/src/test/resources/META-INF/persistence.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~
-  ~  Copyright (c) 2024 Contributors to the Eclipse Foundation
+  ~  Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
   ~   All rights reserved. This program and the accompanying materials
   ~   are made available under the terms of the Eclipse Public License v1.0
   ~   and Apache License v2.0 which accompanies this distribution.

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/pom.xml
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/pom.xml
@@ -97,7 +97,7 @@
         <dependency>
             <groupId>org.jboss.weld.se</groupId>
             <artifactId>weld-se-core</artifactId>
-            <version>6.0.0.Beta1</version>
+            <version>6.0.0.Final</version>
             <scope>test</scope>
         </dependency>
 

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/BaseQueryParser.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/BaseQueryParser.java
@@ -132,6 +132,8 @@ abstract class BaseQueryParser {
                     parseLike(criteria, ctx, ignoreCase);
                 case CONTAINS ->
                     parseContains(criteria, ctx, ignoreCase);
+                case STARTS_WITH ->
+                    parseStartsWith(criteria, ctx, ignoreCase);
                 case ENDS_WITH ->
                     parseEndsWith(criteria, ctx, ignoreCase);
                 case IGNORE_CASE ->
@@ -209,6 +211,11 @@ abstract class BaseQueryParser {
     private static <FROM> Predicate parseContains(CriteriaCondition criteria, QueryContext<FROM> ctx, boolean ignoreCase) {
         StringContext stringContext = StringContext.from(ctx, criteria, ignoreCase);
         return ctx.builder().like(stringContext.field(), "%" + stringContext.fieldValue() + "%");
+    }
+
+    private static <FROM> Predicate parseStartsWith(CriteriaCondition criteria, QueryContext<FROM> ctx, boolean ignoreCase) {
+        StringContext stringContext = StringContext.from(ctx, criteria, ignoreCase);
+        return ctx.builder().like(stringContext.field(), stringContext.fieldValue() + "%");
     }
 
     private static <FROM> Predicate parseEndsWith(CriteriaCondition criteria, QueryContext<FROM> ctx, boolean ignoreCase) {

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/BaseQueryParser.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/BaseQueryParser.java
@@ -164,23 +164,28 @@ Maybe: In,
         if (element.value().isNull()) {
             return ctx.builder().isNull(ctx.root().get(getName(element)));
         } else {
-            Expression<?> leftSide = ctx.root().get(getName(element));
-            Object rightSide = element.value().get();
+            ComparableContext comparableContext = ComparableContext.from(ctx, criteria);
+            Expression<? extends Comparable> leftSide = comparableContext.field();
+            Expression<? extends Comparable> rightSide = comparableContext.expression();
             if (ignoreCase) {
-                if (leftSide.getJavaType().isAssignableFrom(String.class) && rightSide instanceof String) {
+                if (leftAndRightOperandSupportIgnoreCase(leftSide, rightSide)) {
                     leftSide = ctx.builder().upper((Expression<String>) leftSide);
-                    rightSide = rightSide.toString().toUpperCase();
+                    rightSide = ctx.builder().upper((Expression<String>) rightSide);
                 } else {
-                    throw new UnsupportedOperationException("JNoSQL IgnoreCase supported only for String values. Criteria: " + criteria);
+                    throw new UnsupportedOperationException("IgnoreCase supported only for String values. Criteria: " + criteria);
                 }
             }
             return ctx.builder().equal(leftSide, rightSide);
         }
     }
 
+    private static boolean leftAndRightOperandSupportIgnoreCase(Expression<?> leftSide, Expression rightSide) {
+        return leftSide.getJavaType().isAssignableFrom(String.class) && rightSide.getJavaType().isAssignableFrom(String.class);
+    }
+
     private static <FROM> Predicate parseLesserThan(CriteriaCondition criteria, QueryContext<FROM> ctx, boolean ignoreCase) {
         if (ignoreCase) {
-            throw new UnsupportedOperationException("JNoSQL IgnoreCase for condition "
+            throw new UnsupportedOperationException("IgnoreCase for condition "
                     + criteria.condition() + " is not supported yet.");
         }
         ComparableContext comparableContext = ComparableContext.from(ctx, criteria);
@@ -189,7 +194,7 @@ Maybe: In,
 
     private static <FROM> Predicate parseLesserThanEquals(CriteriaCondition criteria, QueryContext<FROM> ctx, boolean ignoreCase) {
         if (ignoreCase) {
-            throw new UnsupportedOperationException("JNoSQL IgnoreCase for condition "
+            throw new UnsupportedOperationException("IgnoreCase for condition "
                     + criteria.condition() + " is not supported yet.");
         }
         ComparableContext comparableContext = ComparableContext.from(ctx, criteria);
@@ -198,7 +203,7 @@ Maybe: In,
 
     private static <FROM> Predicate parseGreaterThan(CriteriaCondition criteria, QueryContext<FROM> ctx, boolean ignoreCase) {
         if (ignoreCase) {
-            throw new UnsupportedOperationException("JNoSQL IgnoreCase for condition "
+            throw new UnsupportedOperationException("IgnoreCase for condition "
                     + criteria.condition() + " is not supported yet.");
         }
         ComparableContext comparableContext = ComparableContext.from(ctx, criteria);
@@ -207,7 +212,7 @@ Maybe: In,
 
     private static <FROM> Predicate parseGreaterEqualsThan(CriteriaCondition criteria, QueryContext<FROM> ctx, boolean ignoreCase) {
         if (ignoreCase) {
-            throw new UnsupportedOperationException("JNoSQL IgnoreCase for condition "
+            throw new UnsupportedOperationException("IgnoreCase for condition "
                     + criteria.condition() + " is not supported yet.");
         }
         ComparableContext comparableContext = ComparableContext.from(ctx, criteria);
@@ -216,7 +221,7 @@ Maybe: In,
 
     private static <FROM> Predicate parseBetween(CriteriaCondition criteria, QueryContext<FROM> ctx, boolean ignoreCase) {
         if (ignoreCase) {
-            throw new UnsupportedOperationException("JNoSQL IgnoreCase for condition "
+            throw new UnsupportedOperationException("IgnoreCase for condition "
                     + criteria.condition() + " is not supported yet.");
         }
         BiComparableContext comparableContext = BiComparableContext.from(ctx, criteria);
@@ -225,7 +230,7 @@ Maybe: In,
 
     private static <FROM> Predicate parseIn(CriteriaCondition criteria, QueryContext<FROM> ctx, boolean ignoreCase) {
         if (ignoreCase) {
-            throw new UnsupportedOperationException("JNoSQL IgnoreCase for condition "
+            throw new UnsupportedOperationException("IgnoreCase for condition "
                     + criteria.condition() + " is not supported yet.");
         }
         MultiValueContext valueContext = MultiValueContext.from(ctx, criteria);
@@ -236,7 +241,7 @@ Maybe: In,
 
     private static <FROM> Predicate parseLike(CriteriaCondition criteria, QueryContext<FROM> ctx, boolean ignoreCase) {
         if (ignoreCase) {
-            throw new UnsupportedOperationException("JNoSQL IgnoreCase for condition "
+            throw new UnsupportedOperationException("IgnoreCase for condition "
                     + criteria.condition() + " is not supported yet.");
         }
         StringContext stringContext = StringContext.from(ctx, criteria);
@@ -245,7 +250,7 @@ Maybe: In,
 
     private static <FROM> Predicate parseContains(CriteriaCondition criteria, QueryContext<FROM> ctx, boolean ignoreCase) {
         if (ignoreCase) {
-            throw new UnsupportedOperationException("JNoSQL IgnoreCase for condition "
+            throw new UnsupportedOperationException("IgnoreCase for condition "
                     + criteria.condition() + " is not supported yet.");
         }
         StringContext stringContext = StringContext.from(ctx, criteria);
@@ -254,7 +259,7 @@ Maybe: In,
 
     private static <FROM> Predicate parseEndsWith(CriteriaCondition criteria, QueryContext<FROM> ctx, boolean ignoreCase) {
         if (ignoreCase) {
-            throw new UnsupportedOperationException("JNoSQL IgnoreCase for condition "
+            throw new UnsupportedOperationException("IgnoreCase for condition "
                     + criteria.condition() + " is not supported yet.");
         }
         StringContext stringContext = StringContext.from(ctx, criteria);

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/EnsureTransaction.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/EnsureTransaction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License v1.0

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/EnsureTransaction.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/EnsureTransaction.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ *
+ *  Contributors:
+ *
+ *  Ondro Mihalyi
+ */
+package org.eclipse.jnosql.jakartapersistence.mapping;
+
+import jakarta.interceptor.InterceptorBinding;
+
+import java.lang.annotation.Inherited;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+
+/**
+ *
+ * @author Ondro Mihalyi
+ */
+@InterceptorBinding
+@Target({TYPE, METHOD})
+@Retention(RUNTIME)
+@Inherited
+public @interface EnsureTransaction {
+}

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/EnsureTransactionInterceptor.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/EnsureTransactionInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License v1.0

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/EnsureTransactionInterceptor.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/EnsureTransactionInterceptor.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ *
+ *  Contributors:
+ *
+ *  Ondro Mihalyi
+ */
+package org.eclipse.jnosql.jakartapersistence.mapping;
+
+import jakarta.annotation.Priority;
+import jakarta.inject.Inject;
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InvocationContext;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityTransaction;
+
+import org.eclipse.jnosql.jakartapersistence.communication.PersistenceDatabaseManager;
+
+
+/**
+ *
+ * @author Ondro Mihalyi
+ */
+@Interceptor
+@EnsureTransaction
+@Priority(100)
+public class EnsureTransactionInterceptor {
+
+    @Inject
+    PersistenceDatabaseManager manager;
+
+    @AroundInvoke
+    public Object intercept(InvocationContext ctx) throws Exception {
+        EntityManager entityManager = manager.getEntityManager();
+        boolean inTransaction = entityManager.isJoinedToTransaction();
+        if (inTransaction) {
+            return ctx.proceed();
+        } else {
+            EntityTransaction transaction = entityManager.getTransaction();
+            transaction.begin();
+            try {
+                Object result = ctx.proceed();
+                transaction.commit();
+                return result;
+            } catch (Exception e) {
+                transaction.rollback();
+                throw e;
+            }
+        }
+    }
+}

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/PersistenceDocumentTemplate.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/PersistenceDocumentTemplate.java
@@ -187,7 +187,7 @@ public class PersistenceDocumentTemplate implements DocumentTemplate {
 
     @Override
     public boolean exists(SelectQuery query) {
-        throw new UnsupportedOperationException("'exists' not supported yet.");
+        return selectParser.exists(query);
     }
 
     @Override

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/PersistenceDocumentTemplate.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/PersistenceDocumentTemplate.java
@@ -35,7 +35,10 @@ import jakarta.persistence.PersistenceUnitUtil;
 
 import java.time.Duration;
 import java.util.Optional;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 import org.eclipse.jnosql.communication.semistructured.DeleteQuery;
 import org.eclipse.jnosql.communication.semistructured.SelectQuery;
@@ -54,6 +57,8 @@ import static org.eclipse.jnosql.jakartapersistence.mapping.QLUtil.isUpdateQuery
 @Database(DatabaseType.DOCUMENT)
 @EnsureTransaction
 public class PersistenceDocumentTemplate implements DocumentTemplate {
+
+    private static final Logger LOGGER = Logger.getLogger(PersistenceDocumentTemplate.class.getName());
 
     private final PersistenceDatabaseManager manager;
     private final SelectQueryParser selectParser;
@@ -214,23 +219,29 @@ public class PersistenceDocumentTemplate implements DocumentTemplate {
     }
 
     @Override
-    public <T> T insert(T t, Duration drtn) {
-        throw new UnsupportedOperationException("'insert(T t, Duration drtn)' not supported yet.");
+    public <T> T insert(T entity, Duration duration) {
+        LOGGER.warning(() -> "Trying to insert an entity with a TTL duration, which is not supported by SQL databases. The duration argument of " + duration + " will be ignored");
+        return insert(entity);
     }
 
     @Override
-    public <T> Iterable<T> insert(Iterable<T> itrbl) {
-        throw new UnsupportedOperationException("'insert(Iterable<T> itrbl)' not supported yet.");
+    public <T> Iterable<T> insert(Iterable<T> entities) {
+        return StreamSupport.stream(entities.spliterator(), false)
+                .map(this::insert)
+                .collect(Collectors.toList());
     }
 
     @Override
-    public <T> Iterable<T> insert(Iterable<T> itrbl, Duration drtn) {
-        throw new UnsupportedOperationException("'insert(Iterable<T> itrbl, Duration drtn)' not supported yet.");
+    public <T> Iterable<T> insert(Iterable<T> entities, Duration duration) {
+        LOGGER.warning(() -> "Trying to insert an entity with a TTL duration, which is not supported by SQL databases. The duration argument of " + duration + " will be ignored");
+        return insert(entities);
     }
 
     @Override
-    public <T> Iterable<T> update(Iterable<T> itrbl) {
-        throw new UnsupportedOperationException("'update' not supported yet.");
+    public <T> Iterable<T> update(Iterable<T> entities) {
+        return StreamSupport.stream(entities.spliterator(), false)
+                .map(this::update)
+                .collect(Collectors.toList());
     }
 
     @Override

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/QueryModifier.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/QueryModifier.java
@@ -42,6 +42,10 @@ interface QueryModifier<FROM, RESULT> extends Function<SelectQueryParser.SelectQ
         return ctx -> ctx.query().select(ctx.builder().count(ctx.root()));
     }
 
+    static <FROM> QueryModifier<FROM, Integer> selectLiteral(int literal) {
+        return ctx -> ctx.query().select(ctx.builder().literal(literal));
+    }
+
     static <FROM, RESULT> QueryModifier<FROM, RESULT> selectColumns(List<String> columns) {
         if (columns.isEmpty()) {
             return ctx -> ctx.query();

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/SelectQueryParser.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/SelectQueryParser.java
@@ -202,14 +202,9 @@ class SelectQueryParser extends BaseQueryParser {
     }
 
     public <T> Optional<T> singleResult(SelectQuery selectQuery) {
-        final Class<T> type = entityClassFromEntityName(selectQuery.name());
-        Optional<T> result;
-        TypedQuery<T> query = buildQuery(type, type, QueryModifier.combine(
-                QueryModifier.selectEntity(),
-                QueryModifier.where(selectQuery.condition())
-        ));
-        result = Optional.ofNullable(toDataExceptions(query::getSingleResultOrNull));
-        return result.map(this::refreshEntity);
+        TypedQuery<T> query = getSelectTypedQuery(selectQuery);
+        return Optional.ofNullable(toDataExceptions(query::getSingleResultOrNull))
+                .map(this::refreshEntity);
     }
 
     private static <T> T toDataExceptions(Supplier<T> supplier) {

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/repository/JakartaPersistenceRepositoryProxy.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/repository/JakartaPersistenceRepositoryProxy.java
@@ -246,7 +246,7 @@ public class JakartaPersistenceRepositoryProxy<T, K> extends AbstractSemiStructu
             requireNonNull(entity, "Entity is required");
 
             K id = getEntityId(entity);
-            template().delete(entityMetadata.type(), id);
+            template().deleteEntity(entity);
         }
 
         private K getEntityId(T entity) {

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/repository/JakartaPersistenceRepositoryProxy.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/repository/JakartaPersistenceRepositoryProxy.java
@@ -29,6 +29,7 @@ import java.util.logging.Logger;
 
 import org.eclipse.jnosql.communication.semistructured.DeleteQuery;
 import org.eclipse.jnosql.communication.semistructured.QueryType;
+import org.eclipse.jnosql.communication.semistructured.SelectQuery;
 import org.eclipse.jnosql.jakartapersistence.mapping.PersistenceDocumentTemplate;
 import org.eclipse.jnosql.jakartapersistence.mapping.PersistencePreparedStatement;
 import org.eclipse.jnosql.mapping.core.Converters;
@@ -126,6 +127,11 @@ public class JakartaPersistenceRepositoryProxy<T, K> extends AbstractSemiStructu
     protected Object executeDeleteByAll(Object instance, Method method, Object[] params) {
         DeleteQuery deleteQuery = deleteQuery(method, params);
         return template().deleteWithCount(deleteQuery);
+    }
+
+    private Object executeOrderByQuery(Object instance, Method method, Object[] params) {
+        SelectQuery selectQuery = query(method, params);
+        return template().select(selectQuery);
     }
 
     @Override

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/repository/JakartaPersistenceRepositoryProxy.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/repository/JakartaPersistenceRepositoryProxy.java
@@ -16,6 +16,7 @@
 package org.eclipse.jnosql.jakartapersistence.mapping.repository;
 
 import jakarta.data.Limit;
+import jakarta.data.exceptions.EmptyResultException;
 import jakarta.data.page.Page;
 import jakarta.data.page.PageRequest;
 import jakarta.data.repository.Query;
@@ -113,7 +114,12 @@ public class JakartaPersistenceRepositoryProxy<T, K> extends AbstractSemiStructu
                 .singleResultPagination(getSingleResult(query))
                 .page(getPage(query))
                 .build();
-        return dynamicReturn.execute();
+        Object result = dynamicReturn.execute();
+        if (result != null) {
+            return result;
+        } else {
+            throw new EmptyResultException("Call to method " + method + " found no matching results.");
+        }
     }
 
     @Override

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/PersonRepository.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/PersonRepository.java
@@ -25,5 +25,6 @@ public interface PersonRepository extends CrudRepository<Person, String> {
     long countByNameNotNull();
     List<Person> findByNameAndAgeLessThanEqual(String name, long age);
     List<Person> findByNameIn(Set<String> names);
+    List<Person> findByNameIgnoreCaseNot(String name);
 }
 

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/PersonRepository.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/PersonRepository.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
  *   are made available under the terms of the Eclipse Public License v1.0
  *   and Apache License v2.0 which accompanies this distribution.

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/PersonRepositoryTest.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/PersonRepositoryTest.java
@@ -130,7 +130,7 @@ public class PersonRepositoryTest {
 
     @Test
     void hermesParser() {
-        getEntityManager().createQuery("UPDATE Person SET length = age + 1");
+        getEntityManager().createQuery("UPDATE Person SET age = age + 1");
     }
 
     private class PersonBuilder {

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/PersonRepositoryTest.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/PersonRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
  *   are made available under the terms of the Eclipse Public License v1.0
  *   and Apache License v2.0 which accompanies this distribution.


### PR DESCRIPTION
A follow-up to https://github.com/eclipse-jnosql/jnosql-extensions/pull/153.

* EqualsIgnoreCase, Contains, EndsWith
* Exists, Or
*  ignoreCase in Like, In, EndsWith
* OrderBy, StartsWith
* run some tests in a separate transaction

Passes 78 tests out of 84 standalone Data 1.0 TCK tests

With a contribution of @aubi to support "Exists".