### PR TITLE
Jakarta Data Persistence - metadata from an EM

### DIFF
--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/pom.xml
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/pom.xml
@@ -164,7 +164,16 @@
             <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
-
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>jnosql-mapping-document</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>jnosql-jakarta-persistence-scanner</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 
     <repositories>

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/src/test/java/org/eclipse/jnosql/tck/jakartapersistence/JNoSqlEntityTests.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/src/test/java/org/eclipse/jnosql/tck/jakartapersistence/JNoSqlEntityTests.java
@@ -14,28 +14,20 @@
  */
 package org.eclipse.jnosql.tck.jakartapersistence;
 
+import org.eclipse.jnosql.jakartapersistence.communication.EntityManagerProvider;
+
 import ee.jakarta.tck.data.standalone.entity.EntityTests;
 
-import org.eclipse.jnosql.jakartapersistence.communication.PersistenceDatabaseManager;
 import org.eclipse.jnosql.jakartapersistence.mapping.PersistenceDocumentTemplate;
 import org.eclipse.jnosql.jakartapersistence.mapping.spi.JakartaPersistenceExtension;
-import org.eclipse.jnosql.mapping.core.Converters;
-import org.eclipse.jnosql.mapping.document.DocumentTemplate;
-import org.eclipse.jnosql.mapping.document.DocumentTemplateProducer;
-import org.eclipse.jnosql.mapping.reflection.Reflections;
-import org.eclipse.jnosql.mapping.reflection.spi.ReflectionEntityMetadataExtension;
-import org.eclipse.jnosql.mapping.semistructured.EntityConverter;
 import org.jboss.weld.junit5.auto.AddExtensions;
 import org.jboss.weld.junit5.auto.AddPackages;
 import org.jboss.weld.junit5.auto.EnableAutoWeld;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @EnableAutoWeld
-@AddPackages(value = {Converters.class, EntityConverter.class, DocumentTemplate.class})
-@AddPackages(DocumentTemplateProducer.class)
-@AddPackages(Reflections.class)
-@AddExtensions({ReflectionEntityMetadataExtension.class, JakartaPersistenceExtension.class})
-@AddPackages({PersistenceDocumentTemplate.class, PersistenceDatabaseManager.class})
+@AddExtensions({JakartaPersistenceExtension.class})
+@AddPackages({PersistenceDocumentTemplate.class, EntityManagerProvider.class})
 @AddPackages({JNoSqlEntityTests.class, EntityTests.class})
 @ExtendWith(TransactionExtension.class)
 public class JNoSqlEntityTests extends EntityTests {

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/src/test/java/org/eclipse/jnosql/tck/jakartapersistence/JNoSqlNoGlobalTxPersistenceEntityTests.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/src/test/java/org/eclipse/jnosql/tck/jakartapersistence/JNoSqlNoGlobalTxPersistenceEntityTests.java
@@ -14,23 +14,18 @@
  */
 package org.eclipse.jnosql.tck.jakartapersistence;
 
+import org.eclipse.jnosql.jakartapersistence.communication.EntityManagerProvider;
+
 import ee.jakarta.tck.data.standalone.persistence.PersistenceEntityTests;
 
-import org.eclipse.jnosql.mapping.core.Converters;
-import org.eclipse.jnosql.mapping.document.DocumentTemplate;
-import org.eclipse.jnosql.mapping.document.DocumentTemplateProducer;
-import org.eclipse.jnosql.mapping.reflection.Reflections;
-import org.eclipse.jnosql.mapping.semistructured.EntityConverter;
 import org.jboss.weld.junit5.auto.AddExtensions;
 import org.jboss.weld.junit5.auto.AddPackages;
 import org.jboss.weld.junit5.auto.EnableAutoWeld;
 
 
 
-import org.eclipse.jnosql.jakartapersistence.communication.PersistenceDatabaseManager;
 import org.eclipse.jnosql.jakartapersistence.mapping.PersistenceDocumentTemplate;
 import org.eclipse.jnosql.jakartapersistence.mapping.spi.JakartaPersistenceExtension;
-import org.eclipse.jnosql.mapping.reflection.spi.ReflectionEntityMetadataExtension;
 import org.eclipse.jnosql.tck.jakartapersistence.junit.RunOnly;
 import org.eclipse.jnosql.tck.jakartapersistence.junit.RunOnlyCondition;
 import org.junit.jupiter.api.Test;
@@ -47,11 +42,8 @@ import ee.jakarta.tck.data.standalone.entity.EntityTests;
  * @author ondro
  */
 @EnableAutoWeld
-@AddPackages(value = {Converters.class, EntityConverter.class, DocumentTemplate.class})
-@AddPackages(value = DocumentTemplateProducer.class)
-@AddPackages(value = Reflections.class)
-@AddExtensions(value = {ReflectionEntityMetadataExtension.class, JakartaPersistenceExtension.class})
-@AddPackages(value = {PersistenceDocumentTemplate.class, PersistenceDatabaseManager.class})
+@AddExtensions({JakartaPersistenceExtension.class})
+@AddPackages({PersistenceDocumentTemplate.class, EntityManagerProvider.class})
 @AddPackages(value = {JNoSqlNoGlobalTxPersistenceEntityTests.class, EntityTests.class})
 @ExtendWith(RunOnlyCondition.class)
 public class JNoSqlNoGlobalTxPersistenceEntityTests extends PersistenceEntityTests {

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/src/test/java/org/eclipse/jnosql/tck/jakartapersistence/JNoSqlPersistenceEntityTests.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/src/test/java/org/eclipse/jnosql/tck/jakartapersistence/JNoSqlPersistenceEntityTests.java
@@ -14,16 +14,12 @@
  */
 package org.eclipse.jnosql.tck.jakartapersistence;
 
+import org.eclipse.jnosql.jakartapersistence.communication.EntityManagerProvider;
+
 import ee.jakarta.tck.data.standalone.persistence.PersistenceEntityTests;
-import org.eclipse.jnosql.jakartapersistence.communication.PersistenceDatabaseManager;
+
 import org.eclipse.jnosql.jakartapersistence.mapping.PersistenceDocumentTemplate;
 import org.eclipse.jnosql.jakartapersistence.mapping.spi.JakartaPersistenceExtension;
-import org.eclipse.jnosql.mapping.core.Converters;
-import org.eclipse.jnosql.mapping.document.DocumentTemplate;
-import org.eclipse.jnosql.mapping.document.DocumentTemplateProducer;
-import org.eclipse.jnosql.mapping.reflection.Reflections;
-import org.eclipse.jnosql.mapping.reflection.spi.ReflectionEntityMetadataExtension;
-import org.eclipse.jnosql.mapping.semistructured.EntityConverter;
 import org.jboss.weld.junit5.auto.AddExtensions;
 import org.jboss.weld.junit5.auto.AddPackages;
 import org.jboss.weld.junit5.auto.EnableAutoWeld;
@@ -32,11 +28,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 
 @EnableAutoWeld
-@AddPackages(value = {Converters.class, EntityConverter.class, DocumentTemplate.class})
-@AddPackages(DocumentTemplateProducer.class)
-@AddPackages(Reflections.class)
-@AddExtensions({ReflectionEntityMetadataExtension.class, JakartaPersistenceExtension.class, JakartaPersistenceExtension.class})
-@AddPackages({PersistenceDocumentTemplate.class, PersistenceDatabaseManager.class})
+@AddExtensions({JakartaPersistenceExtension.class})
+@AddPackages({PersistenceDocumentTemplate.class, EntityManagerProvider.class})
 @AddPackages({JNoSqlPersistenceEntityTests.class, PersistenceEntityTests.class})
 @ExtendWith(TransactionExtension.class)
 public class JNoSqlPersistenceEntityTests extends PersistenceEntityTests {

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/pom.xml
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/pom.xml
@@ -60,11 +60,6 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.jnosql.mapping</groupId>
-            <artifactId>jnosql-jakarta-persistence-scanner</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jnosql.mapping</groupId>
             <artifactId>jnosql-mapping-reflection</artifactId>
             <version>${jnosql-mapping.version}</version>
         </dependency>

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/JNoSQLJakartaPersistence.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/JNoSQLJakartaPersistence.java
@@ -15,12 +15,10 @@
  */
 package org.eclipse.jnosql.jakartapersistence;
 
-import org.eclipse.jnosql.jakartapersistence.mapping.reflection.PersistenceClassScanner;
-
 /**
  *
  * @author Ondro Mihalyi
  */
 public interface JNoSQLJakartaPersistence {
-    static final String PROVIDER = PersistenceClassScanner.PROVIDER;
+    public static final String PROVIDER = "jnosql.jakarta.persistence";
 }

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/JNoSQLJakartaPersistence.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/JNoSQLJakartaPersistence.java
@@ -20,5 +20,5 @@ package org.eclipse.jnosql.jakartapersistence;
  * @author Ondro Mihalyi
  */
 public interface JNoSQLJakartaPersistence {
-    public static final String PROVIDER = "jnosql.jakarta.persistence";
+    public static final String PROVIDER = "Eclipse_JNoSQL_Jakarta_Persistence";
 }

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/communication/JakataPersistenceEntitiesMetadata.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/communication/JakataPersistenceEntitiesMetadata.java
@@ -160,6 +160,8 @@ class JakataPersistenceEntitiesMetadata implements EntitiesMetadata {
 
                 @Override
                 public <X, Y, T extends AttributeConverter<X, Y>> Optional<Class<T>> converter() {
+                    // Not need to convert, EntityManager works with the same type
+                    // and makes the conversion when interacting with the database
                     return Optional.empty();
                 }
 

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/communication/JakataPersistenceEntitiesMetadata.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/communication/JakataPersistenceEntitiesMetadata.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ *
+ *  Contributors:
+ *
+ *  Ondro Mihalyi
+ */
+package org.eclipse.jnosql.jakartapersistence.communication;
+
+import jakarta.nosql.AttributeConverter;
+import jakarta.persistence.metamodel.Attribute;
+import jakarta.persistence.metamodel.EntityType;
+
+import java.lang.annotation.Annotation;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.eclipse.jnosql.communication.Value;
+import org.eclipse.jnosql.mapping.metadata.ConstructorMetadata;
+import org.eclipse.jnosql.mapping.metadata.EntitiesMetadata;
+import org.eclipse.jnosql.mapping.metadata.EntityMetadata;
+import org.eclipse.jnosql.mapping.metadata.FieldMetadata;
+import org.eclipse.jnosql.mapping.metadata.InheritanceMetadata;
+import org.eclipse.jnosql.mapping.metadata.MappingType;
+
+/**
+ *
+ * @author Ondro Mihalyi
+ */
+class JakataPersistenceEntitiesMetadata implements EntitiesMetadata {
+
+    private final PersistenceDatabaseManager databaseManager;
+
+    public JakataPersistenceEntitiesMetadata(PersistenceDatabaseManager databaseManager) {
+        this.databaseManager = databaseManager;
+    }
+
+    @Override
+    public Optional<EntityMetadata> findByClassName(String name) {
+        EntityType<?> entityType;
+        try {
+            entityType = databaseManager.findEntityType(name);
+        } catch (IllegalArgumentException e) {
+            return Optional.empty();
+        }
+        return Optional.of(get(entityType.getJavaType()));
+    }
+
+    @Override
+    public EntityMetadata get(Class<?> entityClass) {
+        final EntityType<?> entityType = databaseManager.getEntityManager().getMetamodel().entity(entityClass);
+        return new EntityMetadata() {
+            @Override
+            public String name() {
+                return entityType.getName();
+            }
+
+            @Override
+            public String simpleName() {
+                return entityClass.getSimpleName();
+            }
+
+            @Override
+            public String className() {
+                return entityClass.getName();
+            }
+
+            @Override
+            public List<String> fieldsName() {
+                return entityType.getAttributes().stream()
+                        .map(Attribute::getName)
+                        .toList();
+            }
+
+            @Override
+            public Class<?> type() {
+                return entityClass;
+            }
+
+            @Override
+            public List<FieldMetadata> fields() {
+                List<FieldMetadata> result = new java.util.ArrayList<>();
+                entityType.getAttributes().stream()
+                        .map(FieldMetadataImpl::new)
+                        .forEach(result::add);
+                return result;
+            }
+
+            @Override
+            public Optional<InheritanceMetadata> inheritance() {
+                //Inheritance for JPA entities shouldn't be handled by JNoSQL directly but by an entityManager
+                return Optional.empty();
+            }
+
+            @Override
+            public String columnField(String javaField) {
+                return javaField;
+            }
+
+            @Override
+            public Optional<FieldMetadata> fieldMapping(String javaField) {
+                try {
+                    Attribute<?, ?> attribute = entityType.getAttribute(javaField);
+                    return Optional.of(new FieldMetadataImpl(attribute));
+                } catch (IllegalArgumentException e) {
+                    return Optional.empty();
+                }
+            }
+
+            @Override
+            public boolean hasEntityName() {
+                throw new UnsupportedOperationException("Is it used or handled by an entityManager?");
+            }
+
+            @Override
+            public boolean isInheritance() {
+                throw new UnsupportedOperationException("Is it used or handled by an entityManager?");
+            }
+
+            @Override
+            public <T> T newInstance() {
+                throw new UnsupportedOperationException("Is it used or handled by an entityManager?");
+            }
+
+            @Override
+            public ConstructorMetadata constructor() {
+                throw new UnsupportedOperationException("Is it used or handled by an entityManager?");
+            }
+
+            @Override
+            public Map<String, FieldMetadata> fieldsGroupByName() {
+                throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+            }
+
+            @Override
+            public Optional<FieldMetadata> id() {
+                throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+            }
+
+            record FieldMetadataImpl(Attribute<?, ?> attribute) implements FieldMetadata {
+
+                @Override
+                public String name() {
+                    return attribute.getName();
+                }
+
+                @Override
+                public Class<?> type() {
+                    return attribute.getJavaType();
+                }
+
+                @Override
+                public <X, Y, T extends AttributeConverter<X, Y>> Optional<Class<T>> converter() {
+                    return Optional.empty();
+                }
+
+                @Override
+                public String fieldName() {
+                    throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+                }
+
+                @Override
+                public Object read(Object bean) {
+                    throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+                }
+
+                @Override
+                public void write(Object bean, Object value) {
+                    throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+                }
+
+                @Override
+                public Object value(Value value) {
+                    throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+                }
+
+                @Override
+                public boolean isId() {
+                    throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+                }
+
+                @Override
+                public Optional<String> udt() {
+                    throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+                }
+
+                @Override
+                public <T extends Annotation> Optional<String> value(Class<T> type) {
+                    throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+                }
+
+                @Override
+                public MappingType mappingType() {
+                    throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+                }
+
+                @Override
+                public <X, Y, T extends AttributeConverter<X, Y>> Optional<T> newConverter() {
+                    throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+                }
+            }
+        };
+    }
+
+    @Override
+    public Map<String, InheritanceMetadata> findByParentGroupByDiscriminatorValue(Class<?> parent) {
+        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public EntityMetadata findByName(String name) {
+        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public Optional<EntityMetadata> findBySimpleName(String name) {
+        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+}

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/communication/PersistenceDatabaseManager.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/communication/PersistenceDatabaseManager.java
@@ -20,6 +20,9 @@ import jakarta.persistence.metamodel.EntityType;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.eclipse.jnosql.mapping.metadata.EntitiesMetadata;
+
+// TODO Cache metadata for the same persistence unit
 public class PersistenceDatabaseManager {
 
     private final EntityManager em;
@@ -31,15 +34,8 @@ public class PersistenceDatabaseManager {
         cacheEntityTypes();
     }
 
-    public PersistenceDatabaseManager() {
-        em = null;
-    }
-
     public EntityManager getEntityManager() {
         return em;
-    }
-
-    public void close() {
     }
 
     public <T> EntityType<T> findEntityType(String entityName) {
@@ -64,4 +60,7 @@ public class PersistenceDatabaseManager {
         });
     }
 
+    public EntitiesMetadata getEntitiesMetadata() {
+        return new JakataPersistenceEntitiesMetadata(this);
+    }
 }

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/metadata/JakartaPersistenceClassScanner.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/metadata/JakartaPersistenceClassScanner.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ *
+ *  Contributors:
+ *
+ *  Ondro Mihalyi
+ */
+package org.eclipse.jnosql.jakartapersistence.mapping.metadata;
+
+import java.util.ServiceLoader;
+
+import org.eclipse.jnosql.mapping.metadata.ClassScanner;
+import org.eclipse.jnosql.mapping.metadata.MetadataException;
+
+/**
+ * This is an extension of {@link ClassScanner} which is to be used for Jakarta Persistence entities.
+ * It contains the same methods as {@link ClassScanner} but returns Jakarta Persistence entities and
+ * embeddables instead of NoSQL ones.
+ * @author Ondro Mihalyi
+ */
+public interface JakartaPersistenceClassScanner extends ClassScanner {
+
+    JakartaPersistenceClassScanner INSTANCE =  ServiceLoader.load(JakartaPersistenceClassScanner.class)
+            .findFirst()
+            .orElseThrow(() ->   new MetadataException("No implementation of JakartaPersistenceClassScanner found via ServiceLoader"));
+
+    /**
+     * Loads and returns an instance of the {@link JakartaPersistenceClassScanner} implementation using the ServiceLoader mechanism.
+     *
+     * @return An instance of the loaded {@link JakartaPersistenceClassScanner} implementation.
+     * @throws IllegalStateException If no suitable implementation is found.
+     */
+    static JakartaPersistenceClassScanner load() {
+        return INSTANCE;
+    }
+}

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/repository/AbstractRepositoryPersistenceBean.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/repository/AbstractRepositoryPersistenceBean.java
@@ -105,9 +105,11 @@ public abstract class AbstractRepositoryPersistenceBean<T> extends AbstractBean<
 
         var entities = databaseManager.getEntitiesMetadata();
         var template = new PersistenceDocumentTemplate(databaseManager);
-        var converters = getInstance(Converters.class);
+        // converters required by JNoSQL core but are not used because
+        /// JakataPersistenceEntitiesMetadata doesn't return a converter - lets EntityManager to convert'
+        var dummyConverters = new Converters(){};
 
-        var handler = createInvocationHandler(entities, template, converters);
+        var handler = createInvocationHandler(entities, template, dummyConverters);
 
         T proxy = (T) Proxy.newProxyInstance(type.getClassLoader(), new Class[]{type}, handler);
 

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/repository/CustomRepositoryPersistenceBean.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/repository/CustomRepositoryPersistenceBean.java
@@ -16,16 +16,15 @@
  */
 package org.eclipse.jnosql.jakartapersistence.mapping.repository;
 
-import jakarta.enterprise.context.spi.CreationalContext;
 import jakarta.enterprise.inject.spi.BeanManager;
 
+import java.lang.reflect.InvocationHandler;
+
 import org.eclipse.jnosql.mapping.core.Converters;
-import org.eclipse.jnosql.mapping.metadata.EntitiesMetadata;
 
-import java.lang.reflect.Proxy;
-
-import org.eclipse.jnosql.jakartapersistence.CdiUtil;
+import org.eclipse.jnosql.jakartapersistence.mapping.PersistenceDocumentTemplate;
 import org.eclipse.jnosql.mapping.core.spi.AbstractBean;
+import org.eclipse.jnosql.mapping.metadata.EntitiesMetadata;
 
 
 /**
@@ -48,23 +47,14 @@ public class CustomRepositoryPersistenceBean<T> extends AbstractRepositoryPersis
         super(type, beanManager);
     }
 
-    @SuppressWarnings("unchecked")
     @Override
-    public T create(CreationalContext<T> context) {
-        var entities = getInstance(EntitiesMetadata.class);
-        var template = createTemplate();
-        var converters = getInstance(Converters.class);
-
-        var handler = CustomRepositoryPersistenceHandler.builder()
-                .entitiesMetadata(entities)
+    protected InvocationHandler createInvocationHandler(EntitiesMetadata entitiesMetadata, PersistenceDocumentTemplate template, Converters converters) {
+        return CustomRepositoryPersistenceHandler.builder()
+                .entitiesMetadata(entitiesMetadata)
                 .template(template)
                 .customRepositoryType(type)
                 .converters(converters)
                 .build();
-
-        T proxy = (T) Proxy.newProxyInstance(type.getClassLoader(), new Class[]{type}, handler);
-
-        return CdiUtil.copyInterceptors(proxy, type, context, beanManager);
     }
 
 }

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/repository/JakartaPersistenceParameterBasedQuery.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/repository/JakartaPersistenceParameterBasedQuery.java
@@ -1,0 +1,91 @@
+/*
+ *  Copyright (c) 2023,2025 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ */
+package org.eclipse.jnosql.jakartapersistence.mapping.repository;
+
+import jakarta.data.Sort;
+
+import org.eclipse.jnosql.communication.semistructured.CriteriaCondition;
+import org.eclipse.jnosql.mapping.semistructured.MappingQuery;
+import org.eclipse.jnosql.mapping.metadata.EntityMetadata;
+import org.eclipse.jnosql.mapping.metadata.FieldMetadata;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.IntFunction;
+
+
+/**
+ * The ColumnParameterBasedQuery class is responsible for generating Column queries based on a set of parameters.
+ * It leverages the provided parameters, PageRequest information, and entity metadata to construct a ColumnQuery object
+ * tailored for querying a specific entity'sort columns.
+ */
+public enum JakartaPersistenceParameterBasedQuery {
+
+
+    INSTANCE;
+    private static final IntFunction<CriteriaCondition[]> TO_ARRAY = CriteriaCondition[]::new;
+
+    /**
+     * Constructs a ColumnQuery based on the provided parameters, PageRequest information, and entity metadata.
+     *
+     * @param params          The map of parameters used for filtering columns.
+     * @param sorts           The list of sorting instructions to to sort the query results
+     * @param entityMetadata  Metadata describing the structure of the entity.
+     * @return                 A ColumnQuery instance tailored for the specified entity.
+     */
+    public org.eclipse.jnosql.communication.semistructured.SelectQuery toQuery(Map<String, Object> params,
+                                                                               List<Sort<?>> sorts,
+                                                                               EntityMetadata entityMetadata) {
+        List<CriteriaCondition> conditions = new ArrayList<>();
+        for (Map.Entry<String, Object> entry : params.entrySet()) {
+            conditions.add(condition(entityMetadata, entry));
+        }
+
+        List<Sort<?>> updateSorter = getSorts(sorts, entityMetadata);
+
+        var condition = condition(conditions);
+        var entity = entityMetadata.name();
+        return new MappingQuery(updateSorter, 0L, 0L, condition, entity, List.of());
+    }
+
+    private CriteriaCondition condition(List<CriteriaCondition> conditions) {
+        if (conditions.isEmpty()) {
+            return null;
+        } else if (conditions.size() == 1) {
+            return conditions.get(0);
+        }
+        return CriteriaCondition.and(conditions.toArray(TO_ARRAY));
+    }
+
+    private CriteriaCondition condition( EntityMetadata entityMetadata, Map.Entry<String, Object> entry) {
+        var name = entityMetadata.fieldMapping(entry.getKey())
+                .map(FieldMetadata::name)
+                .orElse(entry.getKey());
+        var value = entry.getValue();
+        return CriteriaCondition.eq(name, value);
+    }
+
+    private List<Sort<?>> getSorts(List<Sort<?>> sorts, EntityMetadata entityMetadata) {
+        List<Sort<?>> updateSorter = new ArrayList<>();
+        for (Sort<?> sort : sorts) {
+            var name = entityMetadata.fieldMapping(sort.property())
+                    .map(FieldMetadata::name)
+                    .orElse(sort.property());
+            updateSorter.add(sort.isAscending()? Sort.asc(name): Sort.desc(name));
+        }
+        return updateSorter;
+    }
+}

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/repository/JakartaPersistenceRepositoryProxy.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/repository/JakartaPersistenceRepositoryProxy.java
@@ -198,6 +198,11 @@ public class JakartaPersistenceRepositoryProxy<T, K> extends AbstractSemiStructu
     }
 
     @Override
+    protected SelectQuery toQuery(Map<String, Object> parameters, Method method) {
+        return JakartaPersistenceParameterBasedQuery.INSTANCE.toQuery(parameters, getSorts(method, entityMetadata()), entityMetadata());
+    }
+
+    @Override
     protected Function<PageRequest, Page<T>> getPage(org.eclipse.jnosql.communication.semistructured.SelectQuery query) {
         return p -> template().selectOffSet(query, p);
     }

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/repository/RepositoryPersistenceBean.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/repository/RepositoryPersistenceBean.java
@@ -16,23 +16,24 @@
 package org.eclipse.jnosql.jakartapersistence.mapping.repository;
 
 import jakarta.data.repository.DataRepository;
-import jakarta.enterprise.context.spi.CreationalContext;
 import jakarta.enterprise.inject.spi.BeanManager;
+
+import java.lang.reflect.InvocationHandler;
 
 import org.eclipse.jnosql.mapping.core.Converters;
 
-import java.lang.reflect.Proxy;
-
-import org.eclipse.jnosql.jakartapersistence.CdiUtil;
+import org.eclipse.jnosql.jakartapersistence.mapping.PersistenceDocumentTemplate;
 import org.eclipse.jnosql.mapping.core.spi.AbstractBean;
 import org.eclipse.jnosql.mapping.metadata.EntitiesMetadata;
 
-
 /**
- * This class serves as a JNoSQL discovery bean for CDI extension, responsible for registering Repository instances for Jakarta Persistence entities.
- * It extends {@link AbstractBean} and is parameterized with type {@code T} representing the repository type.
+ * This class serves as a JNoSQL discovery bean for CDI extension, responsible
+ * for registering Repository instances for Jakarta Persistence entities. It
+ * extends {@link AbstractBean} and is parameterized with type {@code T}
+ * representing the repository type.
  * <p>
- * Upon instantiation, it initializes with the provided repository type and qualifiers.
+ * Upon instantiation, it initializes with the provided repository type and
+ * qualifiers.
  * </p>
  *
  * @param <T> the type of the repository
@@ -51,15 +52,8 @@ public class RepositoryPersistenceBean<T extends DataRepository<T, ?>> extends A
     }
 
     @Override
-    public T create(CreationalContext<T> context) {
-        var entities = getInstance(EntitiesMetadata.class);
-        var template = createTemplate();
-        var converters = getInstance(Converters.class);
-
-        var handler = new JakartaPersistenceRepositoryProxy<>(template, entities, type, converters);
-        T proxy = (T) Proxy.newProxyInstance(type.getClassLoader(), new Class[]{type}, handler);
-
-        return CdiUtil.copyInterceptors(proxy, type, context, beanManager);
+    protected InvocationHandler createInvocationHandler(EntitiesMetadata entitiesMetadata, PersistenceDocumentTemplate template, Converters converters) {
+        return new JakartaPersistenceRepositoryProxy<>(template, entitiesMetadata, type, converters);
     }
 
 }

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/spi/JakartaPersistenceExtension.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/spi/JakartaPersistenceExtension.java
@@ -14,12 +14,12 @@
  */
 package org.eclipse.jnosql.jakartapersistence.mapping.spi;
 
+import org.eclipse.jnosql.jakartapersistence.mapping.metadata.JakartaPersistenceClassScanner;
+
 import jakarta.enterprise.event.Observes;
 import jakarta.enterprise.inject.spi.AfterBeanDiscovery;
 import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.enterprise.inject.spi.Extension;
-
-import org.eclipse.jnosql.mapping.metadata.ClassScanner;
 
 import java.util.Set;
 import java.util.logging.Logger;
@@ -37,15 +37,15 @@ public class JakartaPersistenceExtension implements Extension {
 
     private static final Logger LOGGER = Logger.getLogger(JakartaPersistenceExtension.class.getName());
 
-    private ClassScanner scanner;
+    private JakartaPersistenceClassScanner scanner;
 
-    public void setScanner(ClassScanner scanner) {
+    public void setScanner(JakartaPersistenceClassScanner scanner) {
         this.scanner = scanner;
     }
 
     void onAfterBeanDiscovery(@Observes final AfterBeanDiscovery afterBeanDiscovery, BeanManager beanManager) {
 
-        ClassScanner scanner = this.scanner != null ? this.scanner : ClassScanner.load();
+        JakartaPersistenceClassScanner scanner = this.scanner != null ? this.scanner : JakartaPersistenceClassScanner.load();
 
         Set<Class<?>> crudTypes = scanner.repositoriesStandard();
         Set<Class<?>> customRepositories = scanner.customRepositories();

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-scanner/pom.xml
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-scanner/pom.xml
@@ -52,6 +52,11 @@
             <artifactId>jakarta.persistence-api</artifactId>
             <version>3.2.0</version>
         </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>jnosql-jakarta-persistence</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-scanner/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/reflection/PersistenceClassScannerSingleton.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-scanner/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/reflection/PersistenceClassScannerSingleton.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.logging.Logger;
 
+import org.eclipse.jnosql.jakartapersistence.JNoSQLJakartaPersistence;
 import org.eclipse.jnosql.mapping.NoSQLRepository;
 import org.eclipse.jnosql.mapping.metadata.ClassScanner;
 
@@ -144,7 +145,7 @@ enum PersistenceClassScannerSingleton implements ClassScanner {
                     final Object provider = c.getAnnotationInfo(Repository.class).getParameterValues().getValue("provider");
                     if (provider instanceof String providerName) {
                         if (providerName.equals(Repository.ANY_PROVIDER)
-                                || providerName.equals(PersistenceClassScanner.PROVIDER)) {
+                                || providerName.equals(JNoSQLJakartaPersistence.PROVIDER)) {
                             return true;
                         }
                     }

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-scanner/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/reflection/ReflectionJakartaPersistenceClassScanner.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-scanner/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/reflection/ReflectionJakartaPersistenceClassScanner.java
@@ -15,12 +15,13 @@
 package org.eclipse.jnosql.jakartapersistence.mapping.reflection;
 
 import jakarta.data.repository.DataRepository;
+
 import java.util.Set;
-import org.eclipse.jnosql.mapping.metadata.ClassScanner;
 
-public class PersistenceClassScanner implements ClassScanner {
+import org.eclipse.jnosql.jakartapersistence.mapping.metadata.JakartaPersistenceClassScanner;
 
-    public static final String PROVIDER = "jnosql.jakarta.persistence";
+
+public class ReflectionJakartaPersistenceClassScanner implements JakartaPersistenceClassScanner {
 
     @Override
     public Set<Class<?>> entities() {

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-scanner/src/main/resources/META-INF/services/org.eclipse.jnosql.jakartapersistence.mapping.metadata.JakartaPersistenceClassScanner
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-scanner/src/main/resources/META-INF/services/org.eclipse.jnosql.jakartapersistence.mapping.metadata.JakartaPersistenceClassScanner
@@ -1,0 +1,1 @@
+org.eclipse.jnosql.jakartapersistence.mapping.reflection.ReflectionJakartaPersistenceClassScanner

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-scanner/src/main/resources/META-INF/services/org.eclipse.jnosql.mapping.metadata.ClassScanner
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-scanner/src/main/resources/META-INF/services/org.eclipse.jnosql.mapping.metadata.ClassScanner
@@ -1,1 +1,0 @@
-org.eclipse.jnosql.jakartapersistence.mapping.reflection.PersistenceClassScanner


### PR DESCRIPTION
Improves performance and removes the dependency on reflection.

 ClassScanner specific for JPA, to avoid conflicts when using both NoSQL and JPA in the same application.