### PR TITLE
JPA driver - add caching of built queries

### DIFF
--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/communication/PersistenceDatabaseManager.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/communication/PersistenceDatabaseManager.java
@@ -55,4 +55,10 @@ public class PersistenceDatabaseManager {
     public EntitiesMetadata getEntitiesMetadata() {
         return new JakataPersistenceEntitiesMetadata(this);
     }
+
+    public PersistenceUnitCache getPersistenceUnitCache() {
+        return persistenceUnitCache;
+    }
+
+    
 }

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/communication/PersistenceDatabaseManager.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/communication/PersistenceDatabaseManager.java
@@ -20,6 +20,12 @@ import jakarta.persistence.metamodel.EntityType;
 import org.eclipse.jnosql.mapping.metadata.EntitiesMetadata;
 import org.eclipse.jnosql.jakartapersistence.mapping.cache.PersistenceUnitCache;
 
+/**
+ * Database manager that provides access to Jakarta Persistence EntityManager
+ * and associated caching functionality. This class serves as a bridge between
+ * the JNoSQL framework and Jakarta Persistence, providing cached access to
+ * entity metadata and query objects.
+ */
 // TODO Cache metadata for the same persistence unit
 public class PersistenceDatabaseManager {
 
@@ -27,15 +33,37 @@ public class PersistenceDatabaseManager {
 
     private final PersistenceUnitCache persistenceUnitCache;
 
+    /**
+     * Constructs a new PersistenceDatabaseManager with the specified EntityManager and cache.
+     *
+     * @param em the EntityManager to use for persistence operations
+     * @param persistenceUnitCache the cache instance for this persistence unit
+     */
     public PersistenceDatabaseManager(EntityManager em, PersistenceUnitCache persistenceUnitCache) {
         this.em = em;
         this.persistenceUnitCache = persistenceUnitCache;
     }
 
+    /**
+     * Returns the underlying EntityManager for direct JPA operations.
+     *
+     * @return the EntityManager instance
+     */
     public EntityManager getEntityManager() {
         return em;
     }
 
+    /**
+     * Finds an EntityType by entity name, with fallback to cached metadata lookup.
+     * This method first attempts to use the standard JPA metamodel lookup,
+     * and if that fails (e.g., with EclipseLink requiring full class names),
+     * it falls back to the cached entity types by name.
+     *
+     * @param <T> the entity type
+     * @param entityName the simple name of the entity
+     * @return the EntityType metadata for the specified entity
+     * @throws IllegalArgumentException if the entity is not found
+     */
     public <T> EntityType<T> findEntityType(String entityName) {
         try {
             return (EntityType<T>) em.getMetamodel().entity(entityName);
@@ -52,10 +80,20 @@ public class PersistenceDatabaseManager {
         }
     }
 
+    /**
+     * Returns the entities metadata wrapper for this database manager.
+     *
+     * @return EntitiesMetadata instance providing access to entity information
+     */
     public EntitiesMetadata getEntitiesMetadata() {
         return new JakataPersistenceEntitiesMetadata(this);
     }
 
+    /**
+     * Returns the persistence unit cache associated with this database manager.
+     *
+     * @return the PersistenceUnitCache instance
+     */
     public PersistenceUnitCache getPersistenceUnitCache() {
         return persistenceUnitCache;
     }

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/communication/PersistenceDatabaseManager.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/communication/PersistenceDatabaseManager.java
@@ -17,21 +17,19 @@ package org.eclipse.jnosql.jakartapersistence.communication;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.metamodel.EntityType;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import org.eclipse.jnosql.mapping.metadata.EntitiesMetadata;
+import org.eclipse.jnosql.jakartapersistence.mapping.cache.PersistenceUnitCache;
 
 // TODO Cache metadata for the same persistence unit
 public class PersistenceDatabaseManager {
 
     private final EntityManager em;
 
-    private final Map<String, EntityType<?>> entityTypesByName = new HashMap<>();
+    private final PersistenceUnitCache persistenceUnitCache;
 
-    public PersistenceDatabaseManager(EntityManager em) {
+    public PersistenceDatabaseManager(EntityManager em, PersistenceUnitCache persistenceUnitCache) {
         this.em = em;
-        cacheEntityTypes();
+        this.persistenceUnitCache = persistenceUnitCache;
     }
 
     public EntityManager getEntityManager() {
@@ -43,7 +41,7 @@ public class PersistenceDatabaseManager {
             return (EntityType<T>) em.getMetamodel().entity(entityName);
         } catch (IllegalArgumentException e) {
             // EclipseLink expects full class name in MM.entity() method. We need to find out the type otherwise
-            EntityType<?> entityType = entityTypesByName.get(entityName);
+            EntityType<?> entityType = persistenceUnitCache.getEntityTypesByName().get(entityName);
             if (entityType != null) {
                 return (EntityType<T>)entityType;
             } else {
@@ -52,12 +50,6 @@ public class PersistenceDatabaseManager {
                 throw ex;
             }
         }
-    }
-
-    private void cacheEntityTypes() {
-        em.getMetamodel().getEntities().forEach(type -> {
-            entityTypesByName.put(type.getName(), type);
-        });
     }
 
     public EntitiesMetadata getEntitiesMetadata() {

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/communication/PersistenceDatabaseManagerProvider.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/communication/PersistenceDatabaseManagerProvider.java
@@ -15,18 +15,53 @@
  */
 package org.eclipse.jnosql.jakartapersistence.communication;
 
+import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.metamodel.EntityType;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.eclipse.jnosql.jakartapersistence.mapping.cache.PersistenceUnitCache;
+import org.eclipse.jnosql.jakartapersistence.mapping.cache.PersistenceUnitCacheProvider;
 
 /**
- * Provides a {@link PersistenceDatabaseManager} for a specific {@link EntityManager}.
+ * Provides a {@link PersistenceDatabaseManager} for a specific
+ * {@link EntityManager}.
+ *
  * @author Ondro Mihalyi
  */
 @ApplicationScoped
 public class PersistenceDatabaseManagerProvider {
 
+    private Map<String, Map<String, EntityType<?>>> entityTypesByNameForPersistenceUnit;
+
+    @Inject
+    private PersistenceUnitCacheProvider persistenceUnitCacheProvider;
+
+    @PostConstruct
+    public void init() {
+        entityTypesByNameForPersistenceUnit = new ConcurrentHashMap<>();
+    }
+
+    private Map<String, EntityType<?>> collectEntityTypesByName(EntityManagerFactory entityManagerFactory) {
+        Map<String, EntityType<?>> entityTypesByName = new ConcurrentHashMap<>();
+        entityManagerFactory.getMetamodel().getEntities().forEach(type -> {
+            entityTypesByName.put(type.getName(), type);
+        });
+        return entityTypesByName;
+    }
+
     public PersistenceDatabaseManager getManager(EntityManager entityManager) {
-        return new PersistenceDatabaseManager(entityManager);
+        EntityManagerFactory entityManagerFactory = entityManager.getEntityManagerFactory();
+        final PersistenceUnitCache persistenceUnitCache = persistenceUnitCacheProvider.getCacheFor(entityManagerFactory);
+        persistenceUnitCache.setEntityTypesByNameSupplier(
+                () -> collectEntityTypesByName(entityManagerFactory)
+        );
+        return new PersistenceDatabaseManager(entityManager, persistenceUnitCache);
     }
 
 }

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/BaseQueryParser.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/BaseQueryParser.java
@@ -50,16 +50,13 @@ import static org.eclipse.jnosql.communication.Condition.LESSER_THAN;
 import static org.eclipse.jnosql.communication.Condition.LIKE;
 import static org.eclipse.jnosql.communication.Condition.NOT;
 
-import org.eclipse.jnosql.jakartapersistence.mapping.cache.PersistenceUnitCache;
 
 abstract class BaseQueryParser {
 
     protected final PersistenceDatabaseManager manager;
-    protected final PersistenceUnitCache persistenceUnitCache;
 
-    protected BaseQueryParser(PersistenceDatabaseManager manager, PersistenceUnitCache persistenceUnitCache) {
+    protected BaseQueryParser(PersistenceDatabaseManager manager) {
         this.manager = manager;
-        this.persistenceUnitCache = persistenceUnitCache;
     }
 
     protected abstract <T> Stream<T> query(String queryString, String entity, Collection<Sort<?>> sorts, Consumer<Query> queryModifier);

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/BaseQueryParser.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/BaseQueryParser.java
@@ -55,11 +55,11 @@ import org.eclipse.jnosql.jakartapersistence.mapping.cache.PersistenceUnitCache;
 abstract class BaseQueryParser {
 
     protected final PersistenceDatabaseManager manager;
-    protected final PersistenceUnitCache queryCache;
+    protected final PersistenceUnitCache persistenceUnitCache;
 
-    protected BaseQueryParser(PersistenceDatabaseManager manager, PersistenceUnitCache queryCache) {
+    protected BaseQueryParser(PersistenceDatabaseManager manager, PersistenceUnitCache persistenceUnitCache) {
         this.manager = manager;
-        this.queryCache = queryCache;
+        this.persistenceUnitCache = persistenceUnitCache;
     }
 
     protected abstract <T> Stream<T> query(String queryString, String entity, Collection<Sort<?>> sorts, Consumer<Query> queryModifier);

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/BaseQueryParser.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/BaseQueryParser.java
@@ -50,12 +50,16 @@ import static org.eclipse.jnosql.communication.Condition.LESSER_THAN;
 import static org.eclipse.jnosql.communication.Condition.LIKE;
 import static org.eclipse.jnosql.communication.Condition.NOT;
 
+import org.eclipse.jnosql.jakartapersistence.mapping.cache.PersistenceUnitCache;
+
 abstract class BaseQueryParser {
 
     protected final PersistenceDatabaseManager manager;
+    protected final PersistenceUnitCache queryCache;
 
-    protected BaseQueryParser(PersistenceDatabaseManager manager) {
+    protected BaseQueryParser(PersistenceDatabaseManager manager, PersistenceUnitCache queryCache) {
         this.manager = manager;
+        this.queryCache = queryCache;
     }
 
     protected abstract <T> Stream<T> query(String queryString, String entity, Collection<Sort<?>> sorts, Consumer<Query> queryModifier);

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/BaseUpdateQueryParser.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/BaseUpdateQueryParser.java
@@ -24,13 +24,14 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import org.eclipse.jnosql.jakartapersistence.communication.PersistenceDatabaseManager;
+import org.eclipse.jnosql.jakartapersistence.mapping.cache.PersistenceUnitCache;
 
 
 class BaseUpdateQueryParser extends BaseQueryParser {
 
 
-    public BaseUpdateQueryParser(PersistenceDatabaseManager manager) {
-        super(manager);
+    public BaseUpdateQueryParser(PersistenceDatabaseManager manager, PersistenceUnitCache queryCache) {
+        super(manager, queryCache);
     }
 
     @Override

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/BaseUpdateQueryParser.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/BaseUpdateQueryParser.java
@@ -24,14 +24,11 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import org.eclipse.jnosql.jakartapersistence.communication.PersistenceDatabaseManager;
-import org.eclipse.jnosql.jakartapersistence.mapping.cache.PersistenceUnitCache;
-
 
 class BaseUpdateQueryParser extends BaseQueryParser {
 
-
-    public BaseUpdateQueryParser(PersistenceDatabaseManager manager, PersistenceUnitCache queryCache) {
-        super(manager, queryCache);
+    public BaseUpdateQueryParser(PersistenceDatabaseManager manager) {
+        super(manager);
     }
 
     @Override

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/DeleteQueryParser.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/DeleteQueryParser.java
@@ -28,14 +28,11 @@ import java.util.function.Function;
 import org.eclipse.jnosql.communication.semistructured.CriteriaCondition;
 import org.eclipse.jnosql.communication.semistructured.DeleteQuery;
 import org.eclipse.jnosql.jakartapersistence.communication.PersistenceDatabaseManager;
-import org.eclipse.jnosql.jakartapersistence.mapping.cache.PersistenceUnitCache;
-
 
 class DeleteQueryParser extends BaseUpdateQueryParser {
 
-
-    public DeleteQueryParser(PersistenceDatabaseManager manager, PersistenceUnitCache queryCache) {
-        super(manager, queryCache);
+    public DeleteQueryParser(PersistenceDatabaseManager manager) {
+        super(manager);
     }
 
     public <T, K> void delete(Class<T> type, K key) {

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/DeleteQueryParser.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/DeleteQueryParser.java
@@ -28,13 +28,14 @@ import java.util.function.Function;
 import org.eclipse.jnosql.communication.semistructured.CriteriaCondition;
 import org.eclipse.jnosql.communication.semistructured.DeleteQuery;
 import org.eclipse.jnosql.jakartapersistence.communication.PersistenceDatabaseManager;
+import org.eclipse.jnosql.jakartapersistence.mapping.cache.PersistenceUnitCache;
 
 
 class DeleteQueryParser extends BaseUpdateQueryParser {
 
 
-    public DeleteQueryParser(PersistenceDatabaseManager manager) {
-        super(manager);
+    public DeleteQueryParser(PersistenceDatabaseManager manager, PersistenceUnitCache queryCache) {
+        super(manager, queryCache);
     }
 
     public <T, K> void delete(Class<T> type, K key) {

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/PersistenceDocumentTemplate.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/PersistenceDocumentTemplate.java
@@ -42,6 +42,8 @@ import org.eclipse.jnosql.mapping.document.DocumentTemplate;
 import static org.eclipse.jnosql.jakartapersistence.mapping.QLUtil.isDeleteQuery;
 import static org.eclipse.jnosql.jakartapersistence.mapping.QLUtil.isUpdateQuery;
 
+import org.eclipse.jnosql.jakartapersistence.mapping.cache.PersistenceUnitCache;
+
 public class PersistenceDocumentTemplate implements DocumentTemplate {
 
     private static final Logger LOGGER = Logger.getLogger(PersistenceDocumentTemplate.class.getName());
@@ -52,10 +54,14 @@ public class PersistenceDocumentTemplate implements DocumentTemplate {
     private final UpdateQueryParser updateParser;
 
     public PersistenceDocumentTemplate(PersistenceDatabaseManager manager) {
+        this(manager, null);
+    }
+
+    public PersistenceDocumentTemplate(PersistenceDatabaseManager manager, PersistenceUnitCache queryCache) {
         this.manager = manager;
-        this.selectParser = new SelectQueryParser(manager);
-        this.deleteParser = new DeleteQueryParser(manager);
-        this.updateParser = new UpdateQueryParser(manager);
+        this.selectParser = new SelectQueryParser(manager, queryCache);
+        this.deleteParser = new DeleteQueryParser(manager, queryCache);
+        this.updateParser = new UpdateQueryParser(manager, queryCache);
     }
 
     public EntityManager entityManager() {

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/PersistenceDocumentTemplate.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/PersistenceDocumentTemplate.java
@@ -42,8 +42,6 @@ import org.eclipse.jnosql.mapping.document.DocumentTemplate;
 import static org.eclipse.jnosql.jakartapersistence.mapping.QLUtil.isDeleteQuery;
 import static org.eclipse.jnosql.jakartapersistence.mapping.QLUtil.isUpdateQuery;
 
-import org.eclipse.jnosql.jakartapersistence.mapping.cache.PersistenceUnitCache;
-
 public class PersistenceDocumentTemplate implements DocumentTemplate {
 
     private static final Logger LOGGER = Logger.getLogger(PersistenceDocumentTemplate.class.getName());
@@ -54,14 +52,10 @@ public class PersistenceDocumentTemplate implements DocumentTemplate {
     private final UpdateQueryParser updateParser;
 
     public PersistenceDocumentTemplate(PersistenceDatabaseManager manager) {
-        this(manager, null);
-    }
-
-    public PersistenceDocumentTemplate(PersistenceDatabaseManager manager, PersistenceUnitCache queryCache) {
         this.manager = manager;
-        this.selectParser = new SelectQueryParser(manager, queryCache);
-        this.deleteParser = new DeleteQueryParser(manager, queryCache);
-        this.updateParser = new UpdateQueryParser(manager, queryCache);
+        this.selectParser = new SelectQueryParser(manager);
+        this.deleteParser = new DeleteQueryParser(manager);
+        this.updateParser = new UpdateQueryParser(manager);
     }
 
     public EntityManager entityManager() {

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/SelectQueryParser.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/SelectQueryParser.java
@@ -45,11 +45,12 @@ import org.eclipse.jnosql.jakartapersistence.communication.PersistenceDatabaseMa
 import org.eclipse.jnosql.jakartapersistence.mapping.core.PersistencePage;
 
 import org.eclipse.jnosql.jakartapersistence.mapping.parser.OptionalPartsParser;
+import org.eclipse.jnosql.jakartapersistence.mapping.cache.PersistenceUnitCache;
 
 class SelectQueryParser extends BaseQueryParser {
 
-    public SelectQueryParser(PersistenceDatabaseManager manager) {
-        super(manager);
+    public SelectQueryParser(PersistenceDatabaseManager manager, PersistenceUnitCache queryCache) {
+        super(manager, queryCache);
     }
 
     public long count(String entity) {

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/UpdateQueryParser.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/UpdateQueryParser.java
@@ -15,16 +15,12 @@
  */
 package org.eclipse.jnosql.jakartapersistence.mapping;
 
-
 import org.eclipse.jnosql.jakartapersistence.communication.PersistenceDatabaseManager;
-import org.eclipse.jnosql.jakartapersistence.mapping.cache.PersistenceUnitCache;
-
 
 class UpdateQueryParser extends BaseUpdateQueryParser {
 
-
-    public UpdateQueryParser(PersistenceDatabaseManager manager, PersistenceUnitCache queryCache) {
-        super(manager, queryCache);
+    public UpdateQueryParser(PersistenceDatabaseManager manager) {
+        super(manager);
     }
 
 }

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/cache/MapBasedPersistenceUnitCache.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/cache/MapBasedPersistenceUnitCache.java
@@ -32,6 +32,7 @@ public class MapBasedPersistenceUnitCache implements PersistenceUnitCache {
     private volatile Map<String, EntityType<?>> entityTypesByName = null;
     private Supplier<Map<String, EntityType<?>>> entityTypesByNameSupplier;
     private Map<Object,CriteriaQuery<?>> selectQueryCache = new ConcurrentHashMap<>();
+    private Map<Object,String> stringQueryCache = new ConcurrentHashMap<>();
 
     @Override
     public Map<String, EntityType<?>> getEntityTypesByName() {
@@ -56,6 +57,11 @@ public class MapBasedPersistenceUnitCache implements PersistenceUnitCache {
     public <T> CriteriaQuery<T> getOrCreateSelectQuery(Object key, Function<Object, CriteriaQuery<T>> supplier) {
         CriteriaQuery<?> valueFromCache = selectQueryCache.computeIfAbsent(key, supplier);
         return (CriteriaQuery<T>) valueFromCache;
+    }
+
+    @Override
+    public String getOrCreateStringQuery(Object key, Function<Object, String> supplier) {
+        return stringQueryCache.computeIfAbsent(key, supplier);
     }
 
 }

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/cache/MapBasedPersistenceUnitCache.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/cache/MapBasedPersistenceUnitCache.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ *
+ *  Contributors:
+ *
+ *  Ondro Mihalyi
+ */
+package org.eclipse.jnosql.jakartapersistence.mapping.cache;
+
+import jakarta.persistence.metamodel.EntityType;
+
+import java.util.Map;
+import java.util.function.Supplier;
+
+/**
+ *
+ * @author Ondro Mihalyi
+ */
+public class MapBasedPersistenceUnitCache implements PersistenceUnitCache {
+
+    private volatile Map<String, EntityType<?>> entityTypesByName = null;
+    private Supplier<Map<String, EntityType<?>>> entityTypesByNameSupplier;
+
+    @Override
+    public Map<String, EntityType<?>> getEntityTypesByName() {
+        Map<String, EntityType<?>> entityTypesByNameLocal = this.entityTypesByName;
+        if (entityTypesByNameLocal == null) {
+            synchronized (this) {
+                entityTypesByNameLocal = this.entityTypesByName;
+                if (entityTypesByNameLocal == null) {
+                    this.entityTypesByName = entityTypesByNameLocal = entityTypesByNameSupplier.get();
+                }
+            }
+        }
+        return entityTypesByNameLocal;
+    }
+
+    @Override
+    public void setEntityTypesByNameSupplier(Supplier<Map<String, EntityType<?>>> supplier) {
+        this.entityTypesByNameSupplier = supplier;
+    }
+
+}

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/cache/MapBasedPersistenceUnitCache.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/cache/MapBasedPersistenceUnitCache.java
@@ -15,9 +15,12 @@
  */
 package org.eclipse.jnosql.jakartapersistence.mapping.cache;
 
+import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.metamodel.EntityType;
 
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 /**
@@ -28,6 +31,7 @@ public class MapBasedPersistenceUnitCache implements PersistenceUnitCache {
 
     private volatile Map<String, EntityType<?>> entityTypesByName = null;
     private Supplier<Map<String, EntityType<?>>> entityTypesByNameSupplier;
+    private Map<Object,CriteriaQuery<?>> selectQueryCache = new ConcurrentHashMap<>();
 
     @Override
     public Map<String, EntityType<?>> getEntityTypesByName() {
@@ -46,6 +50,12 @@ public class MapBasedPersistenceUnitCache implements PersistenceUnitCache {
     @Override
     public void setEntityTypesByNameSupplier(Supplier<Map<String, EntityType<?>>> supplier) {
         this.entityTypesByNameSupplier = supplier;
+    }
+
+    @Override
+    public <T> CriteriaQuery<T> getOrCreateSelectQuery(Object key, Function<Object, CriteriaQuery<T>> supplier) {
+        CriteriaQuery<?> valueFromCache = selectQueryCache.computeIfAbsent(key, supplier);
+        return (CriteriaQuery<T>) valueFromCache;
     }
 
 }

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/cache/PersistenceUnitCache.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/cache/PersistenceUnitCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License v1.0
@@ -13,19 +13,18 @@
  *
  *  Ondro Mihalyi
  */
-package org.eclipse.jnosql.jakartapersistence.mapping;
+package org.eclipse.jnosql.jakartapersistence.mapping.cache;
 
+import jakarta.persistence.metamodel.EntityType;
 
-import org.eclipse.jnosql.jakartapersistence.communication.PersistenceDatabaseManager;
-import org.eclipse.jnosql.jakartapersistence.mapping.cache.PersistenceUnitCache;
+import java.util.Map;
+import java.util.function.Supplier;
 
-
-class UpdateQueryParser extends BaseUpdateQueryParser {
-
-
-    public UpdateQueryParser(PersistenceDatabaseManager manager, PersistenceUnitCache queryCache) {
-        super(manager, queryCache);
-    }
-
+/**
+ *
+ * @author Ondro Mihalyi
+ */
+public interface PersistenceUnitCache {
+    Map<String, EntityType<?>> getEntityTypesByName();
+    void setEntityTypesByNameSupplier(Supplier<Map<String, EntityType<?>>> supplier);
 }
-

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/cache/PersistenceUnitCache.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/cache/PersistenceUnitCache.java
@@ -15,9 +15,11 @@
  */
 package org.eclipse.jnosql.jakartapersistence.mapping.cache;
 
+import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.metamodel.EntityType;
 
 import java.util.Map;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 /**
@@ -27,4 +29,5 @@ import java.util.function.Supplier;
 public interface PersistenceUnitCache {
     Map<String, EntityType<?>> getEntityTypesByName();
     void setEntityTypesByNameSupplier(Supplier<Map<String, EntityType<?>>> supplier);
+    <T> CriteriaQuery<T> getOrCreateSelectQuery(Object key, Function<Object, CriteriaQuery<T>> supplier);
 }

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/cache/PersistenceUnitCache.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/cache/PersistenceUnitCache.java
@@ -30,4 +30,5 @@ public interface PersistenceUnitCache {
     Map<String, EntityType<?>> getEntityTypesByName();
     void setEntityTypesByNameSupplier(Supplier<Map<String, EntityType<?>>> supplier);
     <T> CriteriaQuery<T> getOrCreateSelectQuery(Object key, Function<Object, CriteriaQuery<T>> supplier);
+    String getOrCreateStringQuery(Object key, Function<Object, String> supplier);
 }

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/cache/PersistenceUnitCache.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/cache/PersistenceUnitCache.java
@@ -23,12 +23,49 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 /**
+ * Cache interface for persistence unit-level caching of metadata and queries.
+ * This cache is shared across all EntityManagers within the same EntityManagerFactory
+ * to improve performance by avoiding repeated computation of expensive operations.
  *
  * @author Ondro Mihalyi
  */
 public interface PersistenceUnitCache {
+
+    /**
+     * Retrieves a map of entity types indexed by their simple names.
+     * Uses lazy initialization with double-checked locking pattern. The supplier must be set first,
+     * using the {@link #setEntityTypesByNameSupplier(java.util.function.Supplier) } method.
+     *
+     * @return map of entity names to their corresponding EntityType metadata
+     */
     Map<String, EntityType<?>> getEntityTypesByName();
+
+    /**
+     * Sets the supplier function used to compute entity types by name.
+     * This supplier is called only once when the cache is first accessed.
+     *
+     * @param supplier function that computes the entity types map
+     */
     void setEntityTypesByNameSupplier(Supplier<Map<String, EntityType<?>>> supplier);
+
+    /**
+     * Retrieves or creates a cached CriteriaQuery for SELECT operations.
+     * Uses the provided key for cache lookup and the supplier to create new queries.
+     *
+     * @param <T> the result type of the query
+     * @param key cache key used to identify the query
+     * @param supplier function to create the query if not found in cache
+     * @return cached or newly created CriteriaQuery
+     */
     <T> CriteriaQuery<T> getOrCreateSelectQuery(Object key, Function<Object, CriteriaQuery<T>> supplier);
+
+    /**
+     * Retrieves or creates a cached string query.
+     * Used for caching processed query strings to avoid repeated parsing.
+     *
+     * @param key cache key used to identify the query string
+     * @param supplier function to create the query string if not found in cache
+     * @return cached or newly created query string
+     */
     String getOrCreateStringQuery(Object key, Function<Object, String> supplier);
 }

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/cache/PersistenceUnitCacheProvider.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/cache/PersistenceUnitCacheProvider.java
@@ -22,13 +22,22 @@ import jakarta.persistence.EntityManagerFactory;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
+ * CDI-managed provider for PersistenceUnitCache instances.
+ * This application-scoped bean manages cache instances per persistence unit,
+ * ensuring that each EntityManagerFactory gets its own dedicated cache.
+ *
+ * <p>The provider uses the persistence unit name as the cache key to maintain
+ * separate cache instances for different persistence units within the same application.
  *
  * @author Ondro Mihalyi
  */
 @ApplicationScoped
 public class PersistenceUnitCacheProvider {
 
-    // The keys are persistence unit names
+    /**
+     * Map of cache instances indexed by persistence unit names.
+     * Uses ConcurrentHashMap for thread-safe access across multiple threads.
+     */
     private ConcurrentHashMap<String, PersistenceUnitCache> caches;
 
     @PostConstruct
@@ -36,10 +45,25 @@ public class PersistenceUnitCacheProvider {
        caches = new ConcurrentHashMap<>();
     }
 
+    /**
+     * Retrieves or creates a cache instance for the specified EntityManagerFactory.
+     * Uses the persistence unit name as the cache key to ensure proper isolation
+     * between different persistence units.
+     *
+     * @param entityManagerFactory the EntityManagerFactory to get cache for
+     * @return dedicated PersistenceUnitCache instance for the persistence unit
+     */
     public PersistenceUnitCache getCacheFor(EntityManagerFactory entityManagerFactory) {
         return caches.computeIfAbsent(entityManagerFactory.getName(), this::createQueryCache);
     }
 
+    /**
+     * Creates a new cache instance for the specified persistence unit.
+     * Currently returns a MapBasedPersistenceUnitCache implementation.
+     *
+     * @param persistenceUnitName name of the persistence unit
+     * @return new PersistenceUnitCache instance
+     */
     private PersistenceUnitCache createQueryCache(String persistenceUnitName) {
         return new MapBasedPersistenceUnitCache();
     }

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/cache/PersistenceUnitCacheProvider.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/cache/PersistenceUnitCacheProvider.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ *
+ *  Contributors:
+ *
+ *  Ondro Mihalyi
+ */
+package org.eclipse.jnosql.jakartapersistence.mapping.cache;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.persistence.EntityManagerFactory;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ *
+ * @author Ondro Mihalyi
+ */
+@ApplicationScoped
+public class PersistenceUnitCacheProvider {
+
+    // The keys are persistence unit names
+    private ConcurrentHashMap<String, PersistenceUnitCache> caches;
+
+    @PostConstruct
+    public void init() {
+       caches = new ConcurrentHashMap<>();
+    }
+
+    public PersistenceUnitCache getCacheFor(EntityManagerFactory entityManagerFactory) {
+        return caches.computeIfAbsent(entityManagerFactory.getName(), this::createQueryCache);
+    }
+
+    private PersistenceUnitCache createQueryCache(String persistenceUnitName) {
+        return new MapBasedPersistenceUnitCache();
+    }
+
+}

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/EntityManagerAccessTest.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/EntityManagerAccessTest.java
@@ -19,14 +19,10 @@ import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import jakarta.enterprise.inject.se.SeContainer;
-import jakarta.enterprise.inject.se.SeContainerInitializer;
 import jakarta.persistence.EntityManager;
 
 import java.util.Set;
 
-import org.eclipse.jnosql.jakartapersistence.communication.PersistenceDatabaseManager;
-import org.eclipse.jnosql.jakartapersistence.mapping.PersistenceDocumentTemplate;
-import org.eclipse.jnosql.jakartapersistence.mapping.spi.JakartaPersistenceExtension;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -40,11 +36,7 @@ public class EntityManagerAccessTest {
         TestJakartaPersistenceClassScanner.standardRepositories = Set.of(
                 EntityManagerAccessRepository.class, QualifiedEntityManagerRepository.class);
 
-        cdiContainer = SeContainerInitializer.newInstance()
-                .disableDiscovery()
-                .addExtensions(JakartaPersistenceExtension.class)
-                .addPackages(PersistenceDocumentTemplate.class, PersistenceDatabaseManager.class)
-                .addBeanClasses(EntityManagerProducer.class)
+        cdiContainer = TestSupport.cdiInitializerWithDefaultEmProducer()
                 .initialize();
 
     }

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/TestSupport.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/TestSupport.java
@@ -19,6 +19,7 @@ import jakarta.enterprise.inject.se.SeContainerInitializer;
 
 import org.eclipse.jnosql.jakartapersistence.communication.PersistenceDatabaseManager;
 import org.eclipse.jnosql.jakartapersistence.mapping.PersistenceDocumentTemplate;
+import org.eclipse.jnosql.jakartapersistence.mapping.cache.PersistenceUnitCacheProvider;
 import org.eclipse.jnosql.jakartapersistence.mapping.spi.JakartaPersistenceExtension;
 
 /**
@@ -34,7 +35,7 @@ public class TestSupport {
                 .disableDiscovery()
                 .addExtensions(JakartaPersistenceExtension.class)
                 .addPackages(PersistenceDocumentTemplate.class, PersistenceDatabaseManager.class)
-                .addBeanClasses(EntityManagerProducer.class);
+                .addBeanClasses(EntityManagerProducer.class, PersistenceUnitCacheProvider.class);
     }
 
 

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-scanner/src/test/java/org/eclipse/jnosql/jakartapersistence/mapping/reflection/ProviderTest.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-scanner/src/test/java/org/eclipse/jnosql/jakartapersistence/mapping/reflection/ProviderTest.java
@@ -20,6 +20,7 @@ import jakarta.enterprise.inject.se.SeContainerInitializer;
 
 import org.eclipse.jnosql.jakartapersistence.communication.PersistenceDatabaseManager;
 import org.eclipse.jnosql.jakartapersistence.mapping.PersistenceDocumentTemplate;
+import org.eclipse.jnosql.jakartapersistence.mapping.cache.PersistenceUnitCacheProvider;
 import org.eclipse.jnosql.jakartapersistence.mapping.spi.JakartaPersistenceExtension;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -37,7 +38,7 @@ public class ProviderTest {
                 .disableDiscovery()
                 .addExtensions(JakartaPersistenceExtension.class)
                 .addPackages(PersistenceDocumentTemplate.class, PersistenceDatabaseManager.class)
-                .addBeanClasses(EntityManagerProducer.class)
+                .addBeanClasses(EntityManagerProducer.class, PersistenceUnitCacheProvider.class)
                 .initialize();
     }
 


### PR DESCRIPTION
CriteriaQuery is build first time when it's needed and cached for future usage when its repository method is called. We cache according to the JNoSQL conditions, so it's possible that 2 different repository methods will share the same query.