### PR TITLE
Add regression test for Page.totalElements

### DIFF
--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/PageOutsideTransactionTest.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/PageOutsideTransactionTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Apache License v2.0 which accompanies this distribution.
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package ee.omnifish.jnosql.jakartapersistence;
+
+import jakarta.data.page.Page;
+import jakarta.data.page.PageRequest;
+import jakarta.enterprise.inject.se.SeContainer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class PageOutsideTransactionTest {
+
+    private SeContainer cdiContainer;
+    private PagePersonRepository repository;
+
+    @BeforeEach
+    void init() {
+        TestJakartaPersistenceClassScanner.standardRepositories =
+                Set.of(PagePersonRepository.class);
+
+        cdiContainer = TestSupport.cdiInitializerWithDefaultEmProducer()
+                .initialize();
+
+        repository = cdiContainer.select(PagePersonRepository.class).get();
+
+        repository.deleteAllPersons();
+
+        Person alice = new Person();
+        alice.setName("Alice");
+        alice.setAge(30);
+        repository.insert(alice);
+
+        Person alicia = new Person();
+        alicia.setName("Alicia");
+        alicia.setAge(25);
+        repository.insert(alicia);
+    }
+
+    @AfterEach
+    void cleanup() {
+        cdiContainer.close();
+    }
+
+    @Test
+    void totalElementsAccessibleOutsideTransaction() {
+        Page<Person> page =
+                repository.findByNameLike(
+                        "Ali%",
+                        PageRequest.ofPage(1).size(10));
+
+        assertThat(page.totalElements(), is(2L));
+    }
+}

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/PagePersonRepository.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/PagePersonRepository.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Apache License v2.0 which accompanies this distribution.
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package ee.omnifish.jnosql.jakartapersistence;
+
+import jakarta.data.page.Page;
+import jakarta.data.page.PageRequest;
+import jakarta.data.repository.CrudRepository;
+import jakarta.data.repository.Param;
+import jakarta.data.repository.Query;
+import jakarta.data.repository.Repository;
+
+@Repository
+public interface PagePersonRepository extends CrudRepository<Person, String> {
+
+    @Query("FROM Person WHERE name LIKE :name ORDER BY name")
+    Page<Person> findByNameLike(@Param("name") String name, PageRequest pageRequest);
+
+    @Query("DELETE FROM Person")
+    void deleteAllPersons();
+}


### PR DESCRIPTION
## Summary

- Port the regression test for issue #707 to the `main` branch.
- Verify that `Page.totalElements()` is accessible after the repository call completes.
- Reuse the `PersonRepository`-based test scenario from the 1.1.x fix.

## Testing

- `mvn -pl jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver -Dtest=PageOutsideTransactionTest test`
- Passed on the `main` branch.

Related to #707