### PR TITLE
Test enhacement

### DIFF
--- a/jnosql-lite/mapping-lite-column-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/ColumnEntityConverterInheritanceTest.java
+++ b/jnosql-lite/mapping-lite-column-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/ColumnEntityConverterInheritanceTest.java
@@ -36,7 +36,8 @@ import org.eclipse.jnosql.mapping.semistructured.EntityConverter;
 import org.jboss.weld.junit5.auto.AddExtensions;
 import org.jboss.weld.junit5.auto.AddPackages;
 import org.jboss.weld.junit5.auto.EnableAutoWeld;
-import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
@@ -46,8 +47,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 @EnableAutoWeld
 @AddPackages(value = {Converters.class, EntityConverter.class, ColumnTemplate.class})
@@ -58,375 +58,400 @@ class ColumnEntityConverterInheritanceTest {
     @Inject
     private EntityConverter converter;
 
-    @Test
-    void shouldConvertProjectToSmallProject() {
-        CommunicationEntity entity = CommunicationEntity.of("Project");
-        entity.add("_id", "Small Project");
-        entity.add("investor", "Otavio Santana");
-        entity.add("size", "Small");
-        Project project = this.converter.toEntity(entity);
-        assertEquals("Small Project", project.getName());
-        assertEquals(SmallProject.class, project.getClass());
-        SmallProject smallProject = (SmallProject) project;
-        assertEquals("Otavio Santana", smallProject.getInvestor());
-    }
+    @Nested
+    @DisplayName("When converting inherited entities")
+    class WhenTheConversion {
 
-    @Test
-    void shouldConvertProjectToLargeProject() {
-        CommunicationEntity entity = CommunicationEntity.of("Project");
-        entity.add("_id", "Large Project");
-        entity.add("budget", BigDecimal.TEN);
-        entity.add("size", "Large");
-        Project project = this.converter.toEntity(entity);
-        assertEquals("Large Project", project.getName());
-        assertEquals(LargeProject.class, project.getClass());
-        LargeProject smallProject = (LargeProject) project;
-        assertEquals(BigDecimal.TEN, smallProject.getBudget());
-    }
+        @Test
+        @DisplayName("Should convert project to small project")
+        void shouldConvertProjectToSmallProject() {
+            CommunicationEntity entity = CommunicationEntity.of("Project");
+            entity.add("_id", "Small Project");
+            entity.add("investor", "Otavio Santana");
+            entity.add("size", "Small");
+            Project project = converter.toEntity(entity);
+            assertThat(project.getName()).isEqualTo("Small Project");
+            assertThat(project.getClass()).isEqualTo(SmallProject.class);
+            SmallProject smallProject = (SmallProject) project;
+            assertThat(smallProject.getInvestor()).isEqualTo("Otavio Santana");
+        }
 
-    @Test
-    void shouldConvertLargeProjectToCommunicationEntity() {
-        LargeProject project = new LargeProject();
-        project.setName("Large Project");
-        project.setBudget(BigDecimal.TEN);
-        CommunicationEntity entity = this.converter.toCommunication(project);
-        assertNotNull(entity);
-        assertEquals("Project", entity.name());
-        assertEquals(project.getName(), entity.find("_id", String.class).get());
-        assertEquals(project.getBudget(), entity.find("budget", BigDecimal.class).get());
-        assertEquals("Large", entity.find("size", String.class).get());
-    }
+        @Test
+        @DisplayName("Should convert project to large project")
+        void shouldConvertProjectToLargeProject() {
+            CommunicationEntity entity = CommunicationEntity.of("Project");
+            entity.add("_id", "Large Project");
+            entity.add("budget", BigDecimal.TEN);
+            entity.add("size", "Large");
+            Project project = converter.toEntity(entity);
+            assertThat(project.getName()).isEqualTo("Large Project");
+            assertThat(project.getClass()).isEqualTo(LargeProject.class);
+            LargeProject smallProject = (LargeProject) project;
+            assertThat(smallProject.getBudget()).isEqualTo(BigDecimal.TEN);
+        }
 
-    @Test
-    void shouldConvertSmallProjectToCommunicationEntity() {
-        SmallProject project = new SmallProject();
-        project.setName("Small Project");
-        project.setInvestor("Otavio Santana");
-        var entity = this.converter.toCommunication(project);
-        assertNotNull(entity);
-        assertEquals("Project", entity.name());
-        assertEquals(project.getName(), entity.find("_id", String.class).get());
-        assertEquals(project.getInvestor(), entity.find("investor", String.class).get());
-        assertEquals("Small", entity.find("size", String.class).get());
-    }
+        @Test
+        @DisplayName("Should convert large project to communication entity")
+        void shouldConvertLargeProjectToCommunicationEntity() {
+            LargeProject project = new LargeProject();
+            project.setName("Large Project");
+            project.setBudget(BigDecimal.TEN);
+            CommunicationEntity entity = converter.toCommunication(project);
+            assertThat(entity).isNotNull();
+            assertThat(entity.name()).isEqualTo("Project");
+            assertThat(entity.find("_id", String.class).get()).isEqualTo(project.getName());
+            assertThat(entity.find("budget", BigDecimal.class).get()).isEqualTo(project.getBudget());
+            assertThat(entity.find("size", String.class).get()).isEqualTo("Large");
+        }
 
-    @Test
-    void shouldConvertProject() {
-        var entity = CommunicationEntity.of("Project");
-        entity.add("_id", "Project");
-        entity.add("size", "Project");
-        Project project = this.converter.toEntity(entity);
-        assertEquals("Project", project.getName());
-    }
+        @Test
+        @DisplayName("Should convert small project to communication entity")
+        void shouldConvertSmallProjectToCommunicationEntity() {
+            SmallProject project = new SmallProject();
+            project.setName("Small Project");
+            project.setInvestor("Otavio Santana");
+            var entity = converter.toCommunication(project);
+            assertThat(entity).isNotNull();
+            assertThat(entity.name()).isEqualTo("Project");
+            assertThat(entity.find("_id", String.class).get()).isEqualTo(project.getName());
+            assertThat(entity.find("investor", String.class).get()).isEqualTo(project.getInvestor());
+            assertThat(entity.find("size", String.class).get()).isEqualTo("Small");
+        }
 
-    @Test
-    void shouldConvertProjectToCommunicationEntity() {
-        Project project = new Project();
-        project.setName("Large Project");
-        var entity = this.converter.toCommunication(project);
-        assertNotNull(entity);
-        assertEquals("Project", entity.name());
-        assertEquals(project.getName(), entity.find("_id", String.class).get());
-        assertEquals("Project", entity.find("size", String.class).get());
-    }
+        @Test
+        @DisplayName("Should convert project")
+        void shouldConvertProject() {
+            var entity = CommunicationEntity.of("Project");
+            entity.add("_id", "Project");
+            entity.add("size", "Project");
+            Project project = converter.toEntity(entity);
+            assertThat(project.getName()).isEqualTo("Project");
+        }
 
-    @Test
-    void shouldConvertColumnEntityToSocialMedia(){
-        LocalDate date = LocalDate.now();
-        var entity = CommunicationEntity.of("Notification");
-        entity.add("_id", 100L);
-        entity.add("name", "Social Media");
-        entity.add("nickname", "otaviojava");
-        entity.add("createdOn",date);
-        entity.add("dtype", SocialMediaNotification.class.getSimpleName());
-        SocialMediaNotification notification = this.converter.toEntity(entity);
-        assertEquals(100L, notification.getId());
-        assertEquals("Social Media", notification.getName());
-        assertEquals("otaviojava", notification.getNickname());
-        assertEquals(date, notification.getCreatedOn());
-    }
+        @Test
+        @DisplayName("Should convert project to communication entity")
+        void shouldConvertProjectToCommunicationEntity() {
+            Project project = new Project();
+            project.setName("Large Project");
+            var entity = converter.toCommunication(project);
+            assertThat(entity).isNotNull();
+            assertThat(entity.name()).isEqualTo("Project");
+            assertThat(entity.find("_id", String.class).get()).isEqualTo(project.getName());
+            assertThat(entity.find("size", String.class).get()).isEqualTo("Project");
+        }
 
-    @Test
-    void shouldConvertColumnEntityToSms(){
-        LocalDate date = LocalDate.now();
-        var entity = CommunicationEntity.of("Notification");
-        entity.add("_id", 100L);
-        entity.add("name", "SMS Notification");
-        entity.add("phone", "+351987654123");
-        entity.add("createdOn", date);
-        entity.add("dtype", "SMS");
-        SmsNotification notification = this.converter.toEntity(entity);
-        Assertions.assertEquals(100L, notification.getId());
-        Assertions.assertEquals("SMS Notification", notification.getName());
-        Assertions.assertEquals("+351987654123", notification.getPhone());
-        assertEquals(date, notification.getCreatedOn());
-    }
+        @Test
+        @DisplayName("Should convert column entity to social media notification")
+        void shouldConvertColumnEntityToSocialMedia(){
+            LocalDate date = LocalDate.now();
+            var entity = CommunicationEntity.of("Notification");
+            entity.add("_id", 100L);
+            entity.add("name", "Social Media");
+            entity.add("nickname", "otaviojava");
+            entity.add("createdOn",date);
+            entity.add("dtype", SocialMediaNotification.class.getSimpleName());
+            SocialMediaNotification notification = converter.toEntity(entity);
+            assertThat(notification.getId()).isEqualTo(100L);
+            assertThat(notification.getName()).isEqualTo("Social Media");
+            assertThat(notification.getNickname()).isEqualTo("otaviojava");
+            assertThat(notification.getCreatedOn()).isEqualTo(date);
+        }
 
-    @Test
-    void shouldConvertColumnEntityToEmail(){
-        LocalDate date = LocalDate.now();
-        var entity = CommunicationEntity.of("Notification");
-        entity.add("_id", 100L);
-        entity.add("name", "Email Notification");
-        entity.add("email", "otavio@otavio.test");
-        entity.add("createdOn", date);
-        entity.add("dtype", "Email");
-        EmailNotification notification = this.converter.toEntity(entity);
-        Assertions.assertEquals(100L, notification.getId());
-        Assertions.assertEquals("Email Notification", notification.getName());
-        Assertions.assertEquals("otavio@otavio.test", notification.getEmail());
-        assertEquals(date, notification.getCreatedOn());
-    }
+        @Test
+        @DisplayName("Should convert column entity to SMS notification")
+        void shouldConvertColumnEntityToSms(){
+            LocalDate date = LocalDate.now();
+            var entity = CommunicationEntity.of("Notification");
+            entity.add("_id", 100L);
+            entity.add("name", "SMS Notification");
+            entity.add("phone", "+351987654123");
+            entity.add("createdOn", date);
+            entity.add("dtype", "SMS");
+            SmsNotification notification = converter.toEntity(entity);
+            assertThat(notification.getId()).isEqualTo(100L);
+            assertThat(notification.getName()).isEqualTo("SMS Notification");
+            assertThat(notification.getPhone()).isEqualTo("+351987654123");
+            assertThat(notification.getCreatedOn()).isEqualTo(date);
+        }
 
-    @Test
-    void shouldConvertSocialMediaToCommunicationEntity(){
-        SocialMediaNotification notification = new SocialMediaNotification();
-        notification.setId(100L);
-        notification.setName("Social Media");
-        notification.setCreatedOn(LocalDate.now());
-        notification.setNickname("otaviojava");
-        var entity = this.converter.toCommunication(notification);
-        assertNotNull(entity);
-        assertEquals("Notification", entity.name());
-        assertEquals(notification.getId(), entity.find("_id", Long.class).get());
-        assertEquals(notification.getName(), entity.find("name", String.class).get());
-        assertEquals(notification.getNickname(), entity.find("nickname", String.class).get());
-        assertEquals(notification.getCreatedOn(), entity.find("createdOn", LocalDate.class).get());
-    }
+        @Test
+        @DisplayName("Should convert column entity to email notification")
+        void shouldConvertColumnEntityToEmail(){
+            LocalDate date = LocalDate.now();
+            var entity = CommunicationEntity.of("Notification");
+            entity.add("_id", 100L);
+            entity.add("name", "Email Notification");
+            entity.add("email", "otavio@otavio.test");
+            entity.add("createdOn", date);
+            entity.add("dtype", "Email");
+            EmailNotification notification = converter.toEntity(entity);
+            assertThat(notification.getId()).isEqualTo(100L);
+            assertThat(notification.getName()).isEqualTo("Email Notification");
+            assertThat(notification.getEmail()).isEqualTo("otavio@otavio.test");
+            assertThat(notification.getCreatedOn()).isEqualTo(date);
+        }
 
-    @Test
-    void shouldConvertSmsToCommunicationEntity(){
-        SmsNotification notification = new SmsNotification();
-        notification.setId(100L);
-        notification.setName("SMS");
-        notification.setCreatedOn(LocalDate.now());
-        notification.setPhone("+351123456987");
-        var entity = this.converter.toCommunication(notification);
-        assertNotNull(entity);
-        assertEquals("Notification", entity.name());
-        assertEquals(notification.getId(), entity.find("_id", Long.class).get());
-        assertEquals(notification.getName(), entity.find("name", String.class).get());
-        assertEquals(notification.getPhone(), entity.find("phone", String.class).get());
-        assertEquals(notification.getCreatedOn(), entity.find("createdOn", LocalDate.class).get());
-    }
+        @Test
+        @DisplayName("Should convert social media notification to communication entity")
+        void shouldConvertSocialMediaToCommunicationEntity(){
+            SocialMediaNotification notification = new SocialMediaNotification();
+            notification.setId(100L);
+            notification.setName("Social Media");
+            notification.setCreatedOn(LocalDate.now());
+            notification.setNickname("otaviojava");
+            var entity = converter.toCommunication(notification);
+            assertThat(entity).isNotNull();
+            assertThat(entity.name()).isEqualTo("Notification");
+            assertThat(entity.find("_id", Long.class).get()).isEqualTo(notification.getId());
+            assertThat(entity.find("name", String.class).get()).isEqualTo(notification.getName());
+            assertThat(entity.find("nickname", String.class).get()).isEqualTo(notification.getNickname());
+            assertThat(entity.find("createdOn", LocalDate.class).get()).isEqualTo(notification.getCreatedOn());
+        }
 
-    @Test
-    void shouldConvertEmailToCommunicationEntity(){
-        EmailNotification notification = new EmailNotification();
-        notification.setId(100L);
-        notification.setName("Email Media");
-        notification.setCreatedOn(LocalDate.now());
-        notification.setEmail("otavio@otavio.test.com");
-        CommunicationEntity entity = this.converter.toCommunication(notification);
-        assertNotNull(entity);
-        assertEquals("Notification", entity.name());
-        assertEquals(notification.getId(), entity.find("_id", Long.class).get());
-        assertEquals(notification.getName(), entity.find("name", String.class).get());
-        assertEquals(notification.getEmail(), entity.find("email", String.class).get());
-        assertEquals(notification.getCreatedOn(), entity.find("createdOn", LocalDate.class).get());
-    }
+        @Test
+        @DisplayName("Should convert SMS notification to communication entity")
+        void shouldConvertSmsToCommunicationEntity(){
+            SmsNotification notification = new SmsNotification();
+            notification.setId(100L);
+            notification.setName("SMS");
+            notification.setCreatedOn(LocalDate.now());
+            notification.setPhone("+351123456987");
+            var entity = converter.toCommunication(notification);
+            assertThat(entity).isNotNull();
+            assertThat(entity.name()).isEqualTo("Notification");
+            assertThat(entity.find("_id", Long.class).get()).isEqualTo(notification.getId());
+            assertThat(entity.find("name", String.class).get()).isEqualTo(notification.getName());
+            assertThat(entity.find("phone", String.class).get()).isEqualTo(notification.getPhone());
+            assertThat(entity.find("createdOn", LocalDate.class).get()).isEqualTo(notification.getCreatedOn());
+        }
 
-    @Test
-    void shouldReturnErrorWhenConvertMissingColumn(){
-        LocalDate date = LocalDate.now();
-        var entity = CommunicationEntity.of("Notification");
-        entity.add("_id", 100L);
-        entity.add("name", "SMS Notification");
-        entity.add("phone", "+351987654123");
-        entity.add("createdOn", date);
-        Assertions.assertThrows(MappingException.class, ()-> this.converter.toEntity(entity));
-    }
+        @Test
+        @DisplayName("Should convert email notification to communication entity")
+        void shouldConvertEmailToCommunicationEntity(){
+            EmailNotification notification = new EmailNotification();
+            notification.setId(100L);
+            notification.setName("Email Media");
+            notification.setCreatedOn(LocalDate.now());
+            notification.setEmail("otavio@otavio.test.com");
+            CommunicationEntity entity = converter.toCommunication(notification);
+            assertThat(entity).isNotNull();
+            assertThat(entity.name()).isEqualTo("Notification");
+            assertThat(entity.find("_id", Long.class).get()).isEqualTo(notification.getId());
+            assertThat(entity.find("name", String.class).get()).isEqualTo(notification.getName());
+            assertThat(entity.find("email", String.class).get()).isEqualTo(notification.getEmail());
+            assertThat(entity.find("createdOn", LocalDate.class).get()).isEqualTo(notification.getCreatedOn());
+        }
 
-    @Test
-    void shouldReturnErrorWhenMismatchField() {
-        LocalDate date = LocalDate.now();
-        var entity = CommunicationEntity.of("Notification");
-        entity.add("_id", 100L);
-        entity.add("name", "Email Notification");
-        entity.add("email", "otavio@otavio.test");
-        entity.add("createdOn", date);
-        entity.add("dtype", "Wrong");
-        Assertions.assertThrows(MappingException.class, ()-> this.converter.toEntity(entity));
-    }
+        @Test
+        @DisplayName("Should return an error when column discriminator is missing")
+        void shouldReturnErrorWhenConvertMissingColumn(){
+            LocalDate date = LocalDate.now();
+            var entity = CommunicationEntity.of("Notification");
+            entity.add("_id", 100L);
+            entity.add("name", "SMS Notification");
+            entity.add("phone", "+351987654123");
+            entity.add("createdOn", date);
+            assertThatExceptionOfType(MappingException.class).isThrownBy(() -> converter.toEntity(entity));
+        }
+
+        @Test
+        @DisplayName("Should return an error when discriminator does not match")
+        void shouldReturnErrorWhenMismatchField() {
+            LocalDate date = LocalDate.now();
+            var entity = CommunicationEntity.of("Notification");
+            entity.add("_id", 100L);
+            entity.add("name", "Email Notification");
+            entity.add("email", "otavio@otavio.test");
+            entity.add("createdOn", date);
+            entity.add("dtype", "Wrong");
+            assertThatExceptionOfType(MappingException.class).isThrownBy(() -> converter.toEntity(entity));
+        }
 
 
 
-    @Test
-    void shouldConvertCommunicationNotificationReaderEmail() {
-        var entity = CommunicationEntity.of("NotificationReader");
-        entity.add("_id", "poli");
-        entity.add("name", "Poliana Santana");
-        entity.add("notification", Arrays.asList(
-                Element.of("_id", 10L),
-                Element.of("name", "News"),
-                Element.of("email", "otavio@email.com"),
-                Element.of("_id", LocalDate.now()),
-                Element.of("dtype", "Email")
-        ));
+        @Test
+        @DisplayName("Should convert notification reader with email notification")
+        void shouldConvertCommunicationNotificationReaderEmail() {
+            var entity = CommunicationEntity.of("NotificationReader");
+            entity.add("_id", "poli");
+            entity.add("name", "Poliana Santana");
+            entity.add("notification", Arrays.asList(
+                    Element.of("_id", 10L),
+                    Element.of("name", "News"),
+                    Element.of("email", "otavio@email.com"),
+                    Element.of("_id", LocalDate.now()),
+                    Element.of("dtype", "Email")
+            ));
 
-        NotificationReader notificationReader = converter.toEntity(entity);
-        assertNotNull(notificationReader);
-        Assertions.assertEquals("poli", notificationReader.getNickname());
-        Assertions.assertEquals("Poliana Santana", notificationReader.getName());
-        Notification notification = notificationReader.getNotification();
-        assertNotNull(notification);
-        Assertions.assertEquals(EmailNotification.class, notification.getClass());
-        EmailNotification email = (EmailNotification) notification;
-        Assertions.assertEquals(10L, email.getId());
-        Assertions.assertEquals("News", email.getName());
-        Assertions.assertEquals("otavio@email.com", email.getEmail());
-    }
+            NotificationReader notificationReader = converter.toEntity(entity);
+            assertThat(notificationReader).isNotNull();
+            assertThat(notificationReader.getNickname()).isEqualTo("poli");
+            assertThat(notificationReader.getName()).isEqualTo("Poliana Santana");
+            Notification notification = notificationReader.getNotification();
+            assertThat(notification).isNotNull();
+            assertThat(notification.getClass()).isEqualTo(EmailNotification.class);
+            EmailNotification email = (EmailNotification) notification;
+            assertThat(email.getId()).isEqualTo(10L);
+            assertThat(email.getName()).isEqualTo("News");
+            assertThat(email.getEmail()).isEqualTo("otavio@email.com");
+        }
 
-    @Test
-    void shouldConvertCommunicationNotificationReaderSms() {
-        var entity = CommunicationEntity.of("NotificationReader");
-        entity.add("_id", "poli");
-        entity.add("name", "Poliana Santana");
-        entity.add("notification", Arrays.asList(
-                Element.of("_id", 10L),
-                Element.of("name", "News"),
-                Element.of("phone", "123456789"),
-                Element.of("_id", LocalDate.now()),
-                Element.of("dtype", "SMS")
-        ));
+        @Test
+        @DisplayName("Should convert notification reader with SMS notification")
+        void shouldConvertCommunicationNotificationReaderSms() {
+            var entity = CommunicationEntity.of("NotificationReader");
+            entity.add("_id", "poli");
+            entity.add("name", "Poliana Santana");
+            entity.add("notification", Arrays.asList(
+                    Element.of("_id", 10L),
+                    Element.of("name", "News"),
+                    Element.of("phone", "123456789"),
+                    Element.of("_id", LocalDate.now()),
+                    Element.of("dtype", "SMS")
+            ));
 
-        NotificationReader notificationReader = converter.toEntity(entity);
-        assertNotNull(notificationReader);
-        Assertions.assertEquals("poli", notificationReader.getNickname());
-        Assertions.assertEquals("Poliana Santana", notificationReader.getName());
-        Notification notification = notificationReader.getNotification();
-        assertNotNull(notification);
-        Assertions.assertEquals(SmsNotification.class, notification.getClass());
-        SmsNotification sms = (SmsNotification) notification;
-        Assertions.assertEquals(10L, sms.getId());
-        Assertions.assertEquals("News", sms.getName());
-        Assertions.assertEquals("123456789", sms.getPhone());
-    }
+            NotificationReader notificationReader = converter.toEntity(entity);
+            assertThat(notificationReader).isNotNull();
+            assertThat(notificationReader.getNickname()).isEqualTo("poli");
+            assertThat(notificationReader.getName()).isEqualTo("Poliana Santana");
+            Notification notification = notificationReader.getNotification();
+            assertThat(notification).isNotNull();
+            assertThat(notification.getClass()).isEqualTo(SmsNotification.class);
+            SmsNotification sms = (SmsNotification) notification;
+            assertThat(sms.getId()).isEqualTo(10L);
+            assertThat(sms.getName()).isEqualTo("News");
+            assertThat(sms.getPhone()).isEqualTo("123456789");
+        }
 
-    @Test
-    void shouldConvertCommunicationNotificationReaderSocial() {
-        var entity = CommunicationEntity.of("NotificationReader");
-        entity.add("_id", "poli");
-        entity.add("name", "Poliana Santana");
-        entity.add("notification", Arrays.asList(
-                Element.of("_id", 10L),
-                Element.of("name", "News"),
-                Element.of("nickname", "123456789"),
-                Element.of("_id", LocalDate.now()),
-                Element.of("dtype", "SocialMediaNotification")
-        ));
+        @Test
+        @DisplayName("Should convert notification reader with social notification")
+        void shouldConvertCommunicationNotificationReaderSocial() {
+            var entity = CommunicationEntity.of("NotificationReader");
+            entity.add("_id", "poli");
+            entity.add("name", "Poliana Santana");
+            entity.add("notification", Arrays.asList(
+                    Element.of("_id", 10L),
+                    Element.of("name", "News"),
+                    Element.of("nickname", "123456789"),
+                    Element.of("_id", LocalDate.now()),
+                    Element.of("dtype", "SocialMediaNotification")
+            ));
 
-        NotificationReader notificationReader = converter.toEntity(entity);
-        assertNotNull(notificationReader);
-        Assertions.assertEquals("poli", notificationReader.getNickname());
-        Assertions.assertEquals("Poliana Santana", notificationReader.getName());
-        Notification notification = notificationReader.getNotification();
-        assertNotNull(notification);
-        Assertions.assertEquals(SocialMediaNotification.class, notification.getClass());
-        SocialMediaNotification social = (SocialMediaNotification) notification;
-        Assertions.assertEquals(10L, social.getId());
-        Assertions.assertEquals("News", social.getName());
-        Assertions.assertEquals("123456789", social.getNickname());
-    }
+            NotificationReader notificationReader = converter.toEntity(entity);
+            assertThat(notificationReader).isNotNull();
+            assertThat(notificationReader.getNickname()).isEqualTo("poli");
+            assertThat(notificationReader.getName()).isEqualTo("Poliana Santana");
+            Notification notification = notificationReader.getNotification();
+            assertThat(notification).isNotNull();
+            assertThat(notification.getClass()).isEqualTo(SocialMediaNotification.class);
+            SocialMediaNotification social = (SocialMediaNotification) notification;
+            assertThat(social.getId()).isEqualTo(10L);
+            assertThat(social.getName()).isEqualTo("News");
+            assertThat(social.getNickname()).isEqualTo("123456789");
+        }
 
-    @Test
-    void shouldConvertSocialCommunication() {
-        SocialMediaNotification notification = new SocialMediaNotification();
-        notification.setId(10L);
-        notification.setName("Ada");
-        notification.setNickname("ada.lovelace");
-        NotificationReader reader = new NotificationReader("otavio", "Otavio", notification);
+        @Test
+        @DisplayName("Should convert social notification reader to communication entity")
+        void shouldConvertSocialNotificationReaderToCommunication() {
+            SocialMediaNotification notification = new SocialMediaNotification();
+            notification.setId(10L);
+            notification.setName("Ada");
+            notification.setNickname("ada.lovelace");
+            NotificationReader reader = new NotificationReader("otavio", "Otavio", notification);
 
-        var entity = this.converter.toCommunication(reader);
-        assertNotNull(entity);
+            var entity = converter.toCommunication(reader);
+            assertThat(entity).isNotNull();
 
-        assertEquals("NotificationReader", entity.name());
-        assertEquals("otavio", entity.find("_id", String.class).get());
-        assertEquals("Otavio", entity.find("name", String.class).get());
-        List<Element> columns = entity.find("notification", new TypeReference<List<Element>>() {
-        }).get();
+            assertThat(entity.name()).isEqualTo("NotificationReader");
+            assertThat(entity.find("_id", String.class).get()).isEqualTo("otavio");
+            assertThat(entity.find("name", String.class).get()).isEqualTo("Otavio");
+            List<Element> columns = entity.find("notification", new TypeReference<List<Element>>() {
+            }).get();
 
-        assertThat(columns).contains(Element.of("_id", 10L),
-                Element.of("name", "Ada"),
-                Element.of("dtype", "SocialMediaNotification"),
-                Element.of("nickname", "ada.lovelace"));
-    }
+            assertThat(columns).contains(Element.of("_id", 10L),
+                    Element.of("name", "Ada"),
+                    Element.of("dtype", "SocialMediaNotification"),
+                    Element.of("nickname", "ada.lovelace"));
+        }
 
-    @Test
-    void shouldConvertConvertProjectManagerCommunication() {
-        LargeProject large = new LargeProject();
-        large.setBudget(BigDecimal.TEN);
-        large.setName("large");
+        @Test
+        @DisplayName("Should convert project manager to communication entity")
+        void shouldConvertProjectManagerToCommunication() {
+            LargeProject large = new LargeProject();
+            large.setBudget(BigDecimal.TEN);
+            large.setName("large");
 
-        SmallProject small = new SmallProject();
-        small.setInvestor("new investor");
-        small.setName("Start up");
+            SmallProject small = new SmallProject();
+            small.setInvestor("new investor");
+            small.setName("Start up");
 
-        List<Project> projects = new ArrayList<>();
-        projects.add(large);
-        projects.add(small);
+            List<Project> projects = new ArrayList<>();
+            projects.add(large);
+            projects.add(small);
 
-        ProjectManager manager = ProjectManager.of(10L, "manager", projects);
-        var entity = this.converter.toCommunication(manager);
-        assertNotNull(entity);
+            ProjectManager manager = ProjectManager.of(10L, "manager", projects);
+            var entity = converter.toCommunication(manager);
+            assertThat(entity).isNotNull();
 
-        assertEquals("ProjectManager", entity.name());
-        assertEquals(10L, entity.find("_id", Long.class).get());
-        assertEquals("manager", entity.find("name", String.class).get());
+            assertThat(entity.name()).isEqualTo("ProjectManager");
+            assertThat(entity.find("_id", Long.class).get()).isEqualTo(10L);
+            assertThat(entity.find("name", String.class).get()).isEqualTo("manager");
 
-        List<List<Element>> columns = (List<List<Element>>) entity.find("projects").get().get();
+            List<List<Element>> columns = (List<List<Element>>) entity.find("projects").get().get();
 
-        List<Element> largeCommunication = columns.get(0);
-        List<Element> smallCommunication = columns.get(1);
-        assertThat(largeCommunication).contains(
-                Element.of("_id", "large"),
-                Element.of("size", "Large"),
-                Element.of("budget", BigDecimal.TEN)
-        );
+            List<Element> largeCommunication = columns.get(0);
+            List<Element> smallCommunication = columns.get(1);
+            assertThat(largeCommunication).contains(
+                    Element.of("_id", "large"),
+                    Element.of("size", "Large"),
+                    Element.of("budget", BigDecimal.TEN)
+            );
 
-        assertThat(smallCommunication).contains(
-                Element.of("size", "Small"),
-                Element.of("investor", "new investor"),
-                Element.of("_id", "Start up")
-        );
+            assertThat(smallCommunication).contains(
+                    Element.of("size", "Small"),
+                    Element.of("investor", "new investor"),
+                    Element.of("_id", "Start up")
+            );
 
-    }
+        }
 
-    @Test
-    void shouldConvertConvertCommunicationProjectManager() {
-        var communication = CommunicationEntity.of("ProjectManager");
-        communication.add("_id", 10L);
-        communication.add("name", "manager");
-        List<List<Element>> columns = new ArrayList<>();
-        columns.add(Arrays.asList(
-                Element.of("_id","small-project"),
-                Element.of("size","Small"),
-                Element.of("investor","investor")
-        ));
-        columns.add(Arrays.asList(
-                Element.of("_id","large-project"),
-                Element.of("size","Large"),
-                Element.of("budget",BigDecimal.TEN)
-        ));
-        communication.add("projects", columns);
+        @Test
+        @DisplayName("Should convert communication entity to project manager")
+        void shouldConvertCommunicationToProjectManager() {
+            var communication = CommunicationEntity.of("ProjectManager");
+            communication.add("_id", 10L);
+            communication.add("name", "manager");
+            List<List<Element>> columns = new ArrayList<>();
+            columns.add(Arrays.asList(
+                    Element.of("_id","small-project"),
+                    Element.of("size","Small"),
+                    Element.of("investor","investor")
+            ));
+            columns.add(Arrays.asList(
+                    Element.of("_id","large-project"),
+                    Element.of("size","Large"),
+                    Element.of("budget",BigDecimal.TEN)
+            ));
+            communication.add("projects", columns);
 
-        ProjectManager manager = converter.toEntity(communication);
-        assertNotNull(manager);
+            ProjectManager manager = converter.toEntity(communication);
+            assertThat(manager).isNotNull();
 
-        assertEquals(10L, manager.getId());
-        assertEquals("manager", manager.getName());
+            assertThat(manager.getId()).isEqualTo(10L);
+            assertThat(manager.getName()).isEqualTo("manager");
 
-        List<Project> projects = manager.getProjects();
-        assertEquals(2, projects.size());
-        SmallProject small = (SmallProject) projects.get(0);
-        LargeProject large = (LargeProject) projects.get(1);
-        assertNotNull(small);
-        assertEquals("small-project", small.getName());
-        assertEquals("investor", small.getInvestor());
+            List<Project> projects = manager.getProjects();
+            assertThat(projects.size()).isEqualTo(2);
+            SmallProject small = (SmallProject) projects.get(0);
+            LargeProject large = (LargeProject) projects.get(1);
+            assertThat(small).isNotNull();
+            assertThat(small.getName()).isEqualTo("small-project");
+            assertThat(small.getInvestor()).isEqualTo("investor");
 
-        assertNotNull(large);
-        assertEquals("large-project", large.getName());
-        assertEquals(BigDecimal.TEN, large.getBudget());
+            assertThat(large).isNotNull();
+            assertThat(large.getName()).isEqualTo("large-project");
+            assertThat(large.getBudget()).isEqualTo(BigDecimal.TEN);
 
+        }
     }
 }

--- a/jnosql-lite/mapping-lite-column-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/ColumnEntityConverterTest.java
+++ b/jnosql-lite/mapping-lite-column-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/ColumnEntityConverterTest.java
@@ -15,7 +15,6 @@
 package org.eclipse.jnosql.lite.mapping.entities;
 
 import jakarta.inject.Inject;
-import org.assertj.core.api.SoftAssertions;
 import org.eclipse.jnosql.communication.TypeReference;
 import org.eclipse.jnosql.communication.Value;
 import org.eclipse.jnosql.communication.semistructured.CommunicationEntity;
@@ -28,8 +27,9 @@ import org.eclipse.jnosql.mapping.semistructured.EntityConverter;
 import org.jboss.weld.junit5.auto.AddExtensions;
 import org.jboss.weld.junit5.auto.AddPackages;
 import org.jboss.weld.junit5.auto.EnableAutoWeld;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
@@ -46,7 +46,8 @@ import java.util.stream.Stream;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singleton;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 @EnableAutoWeld
 @AddPackages(value = {Converters.class, EntityConverter.class, ColumnTemplate.class})
@@ -77,463 +78,498 @@ public class ColumnEntityConverterTest {
                 , Element.of("movieRating", Collections.singletonMap("JavaZone", 10))};
     }
 
-    @Test void shouldConvertEntityFromColumnEntity() {
-
-        Person person = Person.builder().withAge()
-                .withId(12)
-                .withName("Otavio")
-                .withPhones(asList("234", "2342")).build();
-
-        var entity = converter.toCommunication(person);
-        assertEquals("Person", entity.name());
-        assertEquals(4, entity.size());
-        assertThat(entity.elements()).contains(Element.of("_id", 12L),
-                Element.of("age", 10), Element.of("name", "Otavio"),
-                Element.of("phones", Arrays.asList("234", "2342")));
-
-    }
-
-    @Test
-    void shouldConvertColumnEntityFromEntity() {
-
-        var entity = converter.toCommunication(actor);
-        assertEquals("Actor", entity.name());
-        assertEquals(6, entity.size());
-
-        assertThat(entity.elements()).contains(columns);
-    }
-
-    @Test
-    void shouldConvertColumnEntityToEntity() {
-        var entity = CommunicationEntity.of("Actor");
-        Stream.of(columns).forEach(entity::add);
-
-        Actor actor = converter.toEntity(Actor.class, entity);
-        assertNotNull(actor);
-        assertEquals(10, actor.getAge());
-        assertEquals(12L, actor.getId());
-        assertEquals(asList("234", "2342"), actor.getPhones());
-        assertEquals(Collections.singletonMap("JavaZone", "Jedi"), actor.getMovieCharacter());
-        assertEquals(Collections.singletonMap("JavaZone", 10), actor.getMovieRating());
-    }
-
-    @Test
-    void shouldConvertColumnEntityToEntity2() {
-        var entity = CommunicationEntity.of("Actor");
-        Stream.of(columns).forEach(entity::add);
-
-        Actor actor = converter.toEntity(entity);
-        assertNotNull(actor);
-        assertEquals(10, actor.getAge());
-        assertEquals(12L, actor.getId());
-        assertEquals(asList("234", "2342"), actor.getPhones());
-        assertEquals(Collections.singletonMap("JavaZone", "Jedi"), actor.getMovieCharacter());
-        assertEquals(Collections.singletonMap("JavaZone", 10), actor.getMovieRating());
-    }
-
-    @Test
-    void shouldConvertColumnEntityToExistEntity() {
-        var entity = CommunicationEntity.of("Actor");
-        Stream.of(columns).forEach(entity::add);
-        Actor actor = Actor.actorBuilder().build();
-        Actor result = converter.toEntity(actor, entity);
-
-        assertSame(actor, result);
-        assertEquals(10, actor.getAge());
-        assertEquals(12L, actor.getId());
-        assertEquals(asList("234", "2342"), actor.getPhones());
-        assertEquals(Collections.singletonMap("JavaZone", "Jedi"), actor.getMovieCharacter());
-        assertEquals(Collections.singletonMap("JavaZone", 10), actor.getMovieRating());
-    }
-
-    @Test
-    void shouldReturnErrorWhenToEntityIsNull() {
-        var entity = CommunicationEntity.of("Actor");
-        Stream.of(columns).forEach(entity::add);
-        Actor actor = Actor.actorBuilder().build();
-
-        assertThrows(NullPointerException.class, () -> converter.toEntity(null, entity));
-
-        assertThrows(NullPointerException.class, () -> converter.toEntity(actor, null));
-    }
-
-
-    @Test
-    void shouldConvertEntityToColumnEntity2() {
-
-        Movie movie = new Movie("Matrix", 2012, Collections.singleton("Actor"));
-        Director director = Director.builderDirector().withAge(12)
-                .withId(12)
-                .withName("Otavio")
-                .withPhones(asList("234", "2342")).withMovie(movie).build();
-
-        var entity = converter.toCommunication(director);
-        assertEquals(5, entity.size());
-
-        assertEquals(getValue(entity.find("name")), director.getName());
-        assertEquals(getValue(entity.find("age")), director.getAge());
-        assertEquals(getValue(entity.find("_id")), director.getId());
-        assertEquals(getValue(entity.find("phones")), director.getPhones());
-
-
-        Element subColumn = entity.find("movie").get();
-        List<Element> columns = subColumn.get(new TypeReference<>() {
-        });
-
-        assertEquals(3, columns.size());
-        assertEquals("movie", subColumn.name());
-        assertEquals(movie.getTitle(), columns.stream().filter(c -> "title".equals(c.name())).findFirst().get().get());
-        assertEquals(movie.getYear(), columns.stream().filter(c -> "year".equals(c.name())).findFirst().get().get());
-        assertEquals(movie.getActors(), columns.stream().filter(c -> "actors".equals(c.name())).findFirst().get().get());
-
-
-    }
-
-    @Test
-    void shouldConvertToEmbeddedClassWhenHasSubColumn() {
-        Movie movie = new Movie("Matrix", 2012, Collections.singleton("Actor"));
-        Director director = Director.builderDirector().withAge(12)
-                .withId(12)
-                .withName("Otavio")
-                .withPhones(asList("234", "2342")).withMovie(movie).build();
-
-        var entity = converter.toCommunication(director);
-        Director director1 = converter.toEntity(entity);
-
-        assertEquals(movie, director1.getMovie());
-        assertEquals(director.getName(), director1.getName());
-        assertEquals(director.getAge(), director1.getAge());
-        assertEquals(director.getId(), director1.getId());
-    }
-
-    @Test
-    void shouldConvertToEmbeddedClassWhenHasSubColumn2() {
-        Movie movie = new Movie("Matrix", 2012, singleton("Actor"));
-        Director director = Director.builderDirector().withAge(12)
-                .withId(12)
-                .withName("Otavio")
-                .withPhones(asList("234", "2342")).withMovie(movie).build();
-
-        var entity = converter.toCommunication(director);
-        entity.remove("movie");
-        entity.add(Element.of("movie", Arrays.asList(Element.of("title", "Matrix"),
-                Element.of("year", 2012), Element.of("actors", singleton("Actor")))));
-        Director director1 = converter.toEntity(entity);
-
-        assertEquals(movie, director1.getMovie());
-        assertEquals(director.getName(), director1.getName());
-        assertEquals(director.getAge(), director1.getAge());
-        assertEquals(director.getId(), director1.getId());
-    }
-
-    @Test
-    void shouldConvertToEmbeddedClassWhenHasSubColumn3() {
-        Movie movie = new Movie("Matrix", 2012, singleton("Actor"));
-        Director director = Director.builderDirector().withAge(12)
-                .withId(12)
-                .withName("Otavio")
-                .withPhones(asList("234", "2342")).withMovie(movie).build();
-
-        var entity = converter.toCommunication(director);
-        entity.remove("movie");
-        Map<String, Object> map = new HashMap<>();
-        map.put("title", "Matrix");
-        map.put("year", 2012);
-        map.put("actors", singleton("Actor"));
-
-        entity.add(Element.of("movie", map));
-        Director director1 = converter.toEntity(entity);
-
-        assertEquals(movie, director1.getMovie());
-        assertEquals(director.getName(), director1.getName());
-        assertEquals(director.getAge(), director1.getAge());
-        assertEquals(director.getId(), director1.getId());
-    }
-
-    @Test
-    void shouldConvertToColumnWhenHaConverter() {
-        Worker worker = new Worker();
-        Job job = new Job();
-        job.setCity("Sao Paulo");
-        job.setDescription("Java Developer");
-        worker.setName("Bob");
-        worker.setSalary(new Money("BRL", BigDecimal.TEN));
-        worker.setJob(job);
-        var entity = converter.toCommunication(worker);
-        assertEquals("Worker", entity.name());
-        assertEquals("Bob", entity.find("name").get().get());
-        assertEquals("Sao Paulo", entity.find("city").get().get());
-        assertEquals("Java Developer", entity.find("description").get().get());
-        assertEquals("BRL 10", entity.find("money").get().get());
-    }
-
-    @Test
-    void shouldConvertToEntityWhenHasConverter() {
-        Worker worker = new Worker();
-        Job job = new Job();
-        job.setCity("Sao Paulo");
-        job.setDescription("Java Developer");
-        worker.setName("Bob");
-        worker.setSalary(new Money("BRL", BigDecimal.TEN));
-        worker.setJob(job);
-        var entity = converter.toCommunication(worker);
-        Worker worker1 = converter.toEntity(entity);
-        assertEquals(worker.getSalary(), worker1.getSalary());
-        assertEquals(job.getCity(), worker1.getJob().getCity());
-        assertEquals(job.getDescription(), worker1.getJob().getDescription());
-    }
-
-    @Test
-    void shouldConvertEmbeddableLazily() {
-        var entity = CommunicationEntity.of("Worker");
-        entity.add("name", "Otavio");
-        entity.add("money", "BRL 10");
-
-        Worker worker = converter.toEntity(entity);
-        assertEquals("Otavio", worker.getName());
-        assertEquals(new Money("BRL", BigDecimal.TEN), worker.getSalary());
-        Assertions.assertNull(worker.getJob());
-
-    }
-
-
-    @Test
-    void shouldConvertToListEmbeddable() {
-        AppointmentBook appointmentBook = new AppointmentBook("ids");
-        appointmentBook.add(Contact.builder().withType(ContactType.EMAIL)
-                .withName("Ada").withInformation("ada@lovelace.com").build());
-        appointmentBook.add(Contact.builder().withType(ContactType.MOBILE)
-                .withName("Ada").withInformation("11 1231231 123").build());
-        appointmentBook.add(Contact.builder().withType(ContactType.PHONE)
-                .withName("Ada").withInformation("12 123 1231 123123").build());
-
-        var entity = converter.toCommunication(appointmentBook);
-        Element contacts = entity.find("contacts").get();
-        assertEquals("ids", appointmentBook.getId());
-        List<List<Element>> columns = (List<List<Element>>) contacts.get();
-
-        assertEquals(3L, columns.stream().flatMap(Collection::stream)
-                .filter(c -> c.name().equals("contact_name"))
-                .count());
-    }
-
-    @Test
-    void shouldConvertFromListEmbeddable() {
-        var entity = CommunicationEntity.of("AppointmentBook");
-        entity.add(Element.of("_id", "ids"));
-        List<List<Element>> columns = new ArrayList<>();
-
-        columns.add(asList(Element.of("contact_name", "Ada"), Element.of("type", ContactType.EMAIL),
-                Element.of("information", "ada@lovelace.com")));
-
-        columns.add(asList(Element.of("contact_name", "Ada"), Element.of("type", ContactType.MOBILE),
-                Element.of("information", "11 1231231 123")));
-
-        columns.add(asList(Element.of("contact_name", "Ada"), Element.of("type", ContactType.PHONE),
-                Element.of("information", "phone")));
-
-        entity.add(Element.of("contacts", columns));
-
-        AppointmentBook appointmentBook = converter.toEntity(entity);
-
-        List<Contact> contacts = appointmentBook.getContacts();
-        assertEquals("ids", appointmentBook.getId());
-        assertEquals("Ada", contacts.stream().map(Contact::getName).distinct().findFirst().get());
-
-    }
-
-
-    @Test
-    void shouldConvertSubEntity() {
-        ZipCode zipcode = new ZipCode();
-        zipcode.setZip("12321");
-        zipcode.setPlusFour("1234");
-
-        Address address = new Address();
-        address.setCity("Salvador");
-        address.setState("Bahia");
-        address.setStreet("Rua Engenheiro Jose Anasoh");
-        address.setZipCode(zipcode);
-
-        var columnEntity = converter.toCommunication(address);
-        List<Element> columns = columnEntity.elements();
-        assertEquals("Address", columnEntity.name());
-        assertEquals(4, columns.size());
-        List<Element> zip = columnEntity.find("zipCode").map(d -> d.get(new TypeReference<List<Element>>() {
-        })).orElse(Collections.emptyList());
-
-        assertEquals("Rua Engenheiro Jose Anasoh", getValue(columnEntity.find("street")));
-        assertEquals("Salvador", getValue(columnEntity.find("city")));
-        assertEquals("Bahia", getValue(columnEntity.find("state")));
-        assertEquals("12321", getValue(zip.stream().filter(d -> d.name().equals("zip")).findFirst()));
-        assertEquals("1234", getValue(zip.stream().filter(d -> d.name().equals("plusFour")).findFirst()));
-    }
-
-    @Test
-    void shouldConvertColumnInSubEntity() {
-
-        var entity = CommunicationEntity.of("Address");
-
-        entity.add(Element.of("street", "Rua Engenheiro Jose Anasoh"));
-        entity.add(Element.of("city", "Salvador"));
-        entity.add(Element.of("state", "Bahia"));
-        entity.add(Element.of("zipCode", Arrays.asList(
-                Element.of("zip", "12321"),
-                Element.of("plusFour", "1234"))));
-        Address address = converter.toEntity(entity);
-
-        assertEquals("Rua Engenheiro Jose Anasoh", address.getStreet());
-        assertEquals("Salvador", address.getCity());
-        assertEquals("Bahia", address.getState());
-        assertEquals("12321", address.getZipCode().getZip());
-        assertEquals("1234", address.getZipCode().getPlusFour());
-
-    }
-
-    @Test
-    void shouldReturnNullWhenThereIsNotSubEntity() {
-        var entity = CommunicationEntity.of("Address");
-
-        entity.add(Element.of("street", "Rua Engenheiro Jose Anasoh"));
-        entity.add(Element.of("city", "Salvador"));
-        entity.add(Element.of("state", "Bahia"));
-        entity.add(Element.of("zip", "12321"));
-        entity.add(Element.of("plusFour", "1234"));
-
-        Address address = converter.toEntity(entity);
-
-        assertEquals("Rua Engenheiro Jose Anasoh", address.getStreet());
-        assertEquals("Salvador", address.getCity());
-        assertEquals("Bahia", address.getState());
-        assertNull(address.getZipCode());
-    }
-
-    @Test
-    void shouldConvertAndDoNotUseUnmodifiableCollection() {
-        var entity = CommunicationEntity.of("vendors");
-        entity.add("name", "name");
-        entity.add("prefixes", Arrays.asList("value", "value2"));
-
-        Vendor vendor = converter.toEntity(entity);
-        vendor.add("value3");
-
-        Assertions.assertEquals(3, vendor.getPrefixes().size());
-
-    }
-
-    @Test
-    void shouldConvertEntityToDocumentWithArray() {
-        byte[] contents = {1, 2, 3, 4, 5, 6};
-
-        var entity = CommunicationEntity.of("download");
-        entity.add("_id", 1L);
-        entity.add("contents", contents);
-
-        Download download = converter.toEntity(entity);
-        Assertions.assertEquals(1L, download.getId());
-        Assertions.assertArrayEquals(contents, download.getContents());
-    }
-
-    @Test
-    void shouldConvertDocumentToEntityWithArray() {
-        byte[] contents = {1, 2, 3, 4, 5, 6};
-
-        Download download = new Download();
-        download.setId(1L);
-        download.setContents(contents);
-
-        var entity = converter.toCommunication(download);
-
-        Assertions.assertEquals(1L, entity.find("_id").get().get());
-        final byte[] bytes = entity.find("contents").map(v -> v.get(byte[].class)).orElse(new byte[0]);
-        Assertions.assertArrayEquals(contents, bytes);
-    }
-
-    @Test
-    void shouldCreateUserScope() {
-        var entity = CommunicationEntity.of("UserScope");
-        entity.add("_id", "userName");
-        entity.add("scope", "scope");
-        entity.add("properties", Collections.singletonList(Element.of("halo", "weld")));
-
-        UserScope user = converter.toEntity(entity);
-        Assertions.assertNotNull(user);
-        Assertions.assertEquals("userName",user.getUserName());
-        Assertions.assertEquals("scope",user.getScope());
-        Assertions.assertEquals(Collections.singletonMap("halo", "weld"),user.getProperties());
-
-    }
-
-    @Test
-    void shouldCreateUserScope2() {
-        var entity = CommunicationEntity.of("UserScope");
-        entity.add("_id", "userName");
-        entity.add("scope", "scope");
-        entity.add("properties", Element.of("halo", "weld"));
-
-        UserScope user = converter.toEntity(entity);
-        Assertions.assertNotNull(user);
-        Assertions.assertEquals("userName",user.getUserName());
-        Assertions.assertEquals("scope",user.getScope());
-        Assertions.assertEquals(Collections.singletonMap("halo", "weld"),user.getProperties());
-
-    }
-
-    @Test
-    void shouldCreateLazilyEntity() {
-        var entity = CommunicationEntity.of("Citizen");
-        entity.add("id", "10");
-        entity.add("name", "Salvador");
-
-        Citizen citizen = converter.toEntity(entity);
-        Assertions.assertNotNull(citizen);
-        Assertions.assertNull(citizen.getCity());
-    }
-
-    @Test
-    void shouldConvertGroupEmbeddable(){
-        CommunicationEntity entity = CommunicationEntity.of("Wine");
-        entity.add("_id", "id");
-        entity.add("name", "Vin Blanc");
-        entity.add("factory", List.of(Element.of("name", "Napa Valley Factory"),
-                Element.of("location", "Napa Valley")));
-
-        Wine wine = converter.toEntity(entity);
-
-        SoftAssertions.assertSoftly(soft ->{
-            WineFactory factory = wine.getFactory();
-            soft.assertThat(wine).isNotNull();
-            soft.assertThat(wine.getId()).isEqualTo("id");
-            soft.assertThat(wine.getName()).isEqualTo("Vin Blanc");
-            soft.assertThat(factory).isNotNull();
-            soft.assertThat(factory.getName()).isEqualTo("Napa Valley Factory");
-            soft.assertThat(factory.getLocation()).isEqualTo("Napa Valley");
-        });
-    }
-
-    @Test
-    void shouldConvertGroupEmbeddableToCommunication(){
-
-        Wine wine = Wine.of("id", "Vin Blanc", WineFactory.of("Napa Valley Factory", "Napa Valley"));
-
-
-        var communication = converter.toCommunication(wine);
-
-        SoftAssertions.assertSoftly(soft ->{
-            soft.assertThat(communication).isNotNull();
-            soft.assertThat(communication.name()).isEqualTo("Wine");
-            soft.assertThat(communication.find("_id").orElseThrow().get()).isEqualTo("id");
-            soft.assertThat(communication.find("name").orElseThrow().get()).isEqualTo("Vin Blanc");
-            communication.find("factory").ifPresent(e -> {
-                List<Element> elements = e.get(new TypeReference<>(){});
-                soft.assertThat(elements).hasSize(2);
-                soft.assertThat(elements.stream().filter(c -> "name".equals(c.name())).findFirst().orElseThrow().get())
-                        .isEqualTo("Napa Valley Factory");
-                soft.assertThat(elements.stream().filter(c -> "location".equals(c.name())).findFirst().orElseThrow().get())
-                        .isEqualTo("Napa Valley");
+    @Nested
+    @DisplayName("When converting entities")
+    class WhenTheConversion {
+
+        @Test
+        @DisplayName("Should convert Entity From Column Entity")
+        void shouldConvertEntityFromColumnEntity() {
+
+            Person person = Person.builder().withAge()
+                    .withId(12)
+                    .withName("Otavio")
+                    .withPhones(asList("234", "2342")).build();
+
+            var entity = converter.toCommunication(person);
+            assertThat(entity.name()).isEqualTo("Person");
+            assertThat(entity.size()).isEqualTo(4);
+            assertThat(entity.elements()).contains(Element.of("_id", 12L),
+                    Element.of("age", 10), Element.of("name", "Otavio"),
+                    Element.of("phones", Arrays.asList("234", "2342")));
+
+        }
+
+        @Test
+        @DisplayName("Should convert Column Entity From Entity")
+        void shouldConvertColumnEntityFromEntity() {
+
+            var entity = converter.toCommunication(actor);
+            assertThat(entity.name()).isEqualTo("Actor");
+            assertThat(entity.size()).isEqualTo(6);
+
+            assertThat(entity.elements()).contains(columns);
+        }
+
+        @Test
+        @DisplayName("Should convert Column Entity To Entity")
+        void shouldConvertColumnEntityToEntity() {
+            var entity = CommunicationEntity.of("Actor");
+            Stream.of(columns).forEach(entity::add);
+
+            Actor actor = converter.toEntity(Actor.class, entity);
+            assertThat(actor).isNotNull();
+            assertThat(actor.getAge()).isEqualTo(10);
+            assertThat(actor.getId()).isEqualTo(12L);
+            assertThat(actor.getPhones()).isEqualTo(asList("234", "2342"));
+            assertThat(actor.getMovieCharacter()).isEqualTo(Collections.singletonMap("JavaZone", "Jedi"));
+            assertThat(actor.getMovieRating()).isEqualTo(Collections.singletonMap("JavaZone", 10));
+        }
+
+        @Test
+        @DisplayName("Should convert to entity without explicit type")
+        void shouldConvertToEntityWithoutExplicitType() {
+            var entity = CommunicationEntity.of("Actor");
+            Stream.of(columns).forEach(entity::add);
+
+            Actor actor = converter.toEntity(entity);
+            assertThat(actor).isNotNull();
+            assertThat(actor.getAge()).isEqualTo(10);
+            assertThat(actor.getId()).isEqualTo(12L);
+            assertThat(actor.getPhones()).isEqualTo(asList("234", "2342"));
+            assertThat(actor.getMovieCharacter()).isEqualTo(Collections.singletonMap("JavaZone", "Jedi"));
+            assertThat(actor.getMovieRating()).isEqualTo(Collections.singletonMap("JavaZone", 10));
+        }
+
+        @Test
+        @DisplayName("Should convert Column Entity To Exist Entity")
+        void shouldConvertColumnEntityToExistEntity() {
+            var entity = CommunicationEntity.of("Actor");
+            Stream.of(columns).forEach(entity::add);
+            Actor actor = Actor.actorBuilder().build();
+            Actor result = converter.toEntity(actor, entity);
+
+            assertThat(result).isSameAs(actor);
+            assertThat(actor.getAge()).isEqualTo(10);
+            assertThat(actor.getId()).isEqualTo(12L);
+            assertThat(actor.getPhones()).isEqualTo(asList("234", "2342"));
+            assertThat(actor.getMovieCharacter()).isEqualTo(Collections.singletonMap("JavaZone", "Jedi"));
+            assertThat(actor.getMovieRating()).isEqualTo(Collections.singletonMap("JavaZone", 10));
+        }
+
+        @Test
+        @DisplayName("Should return an error when entity conversion receives null")
+        void shouldReturnErrorWhenToEntityIsNull() {
+            var entity = CommunicationEntity.of("Actor");
+            Stream.of(columns).forEach(entity::add);
+            Actor actor = Actor.actorBuilder().build();
+
+            assertThatNullPointerException().isThrownBy(() -> converter.toEntity(null, entity));
+
+            assertThatNullPointerException().isThrownBy(() -> converter.toEntity(actor, null));
+        }
+
+
+        @Test
+        @DisplayName("Should convert an entity with an embedded movie")
+        void shouldConvertEntityWithEmbeddedMovie() {
+
+            Movie movie = new Movie("Matrix", 2012, Collections.singleton("Actor"));
+            Director director = Director.builderDirector().withAge(12)
+                    .withId(12)
+                    .withName("Otavio")
+                    .withPhones(asList("234", "2342")).withMovie(movie).build();
+
+            var entity = converter.toCommunication(director);
+            assertThat(entity.size()).isEqualTo(5);
+
+            assertThat(director.getName()).isEqualTo(getValue(entity.find("name")));
+            assertThat(director.getAge()).isEqualTo(getValue(entity.find("age")));
+            assertThat(director.getId()).isEqualTo(getValue(entity.find("_id")));
+            assertThat(director.getPhones()).isEqualTo(getValue(entity.find("phones")));
+
+
+            Element subColumn = entity.find("movie").get();
+            List<Element> columns = subColumn.get(new TypeReference<>() {
             });
 
-        });
+            assertThat(columns.size()).isEqualTo(3);
+            assertThat(subColumn.name()).isEqualTo("movie");
+            assertThat(columns.stream().filter(c -> "title".equals(c.name())).findFirst().get().get()).isEqualTo(movie.getTitle());
+            assertThat(columns.stream().filter(c -> "year".equals(c.name())).findFirst().get().get()).isEqualTo(movie.getYear());
+            assertThat(columns.stream().filter(c -> "actors".equals(c.name())).findFirst().get().get()).isEqualTo(movie.getActors());
+
+
+        }
+
+        @Test
+        @DisplayName("Should convert an embedded class from a column")
+        void shouldConvertToEmbeddedClassWhenHasSubColumn() {
+            Movie movie = new Movie("Matrix", 2012, Collections.singleton("Actor"));
+            Director director = Director.builderDirector().withAge(12)
+                    .withId(12)
+                    .withName("Otavio")
+                    .withPhones(asList("234", "2342")).withMovie(movie).build();
+
+            var entity = converter.toCommunication(director);
+            Director director1 = converter.toEntity(entity);
+
+            assertThat(director1.getMovie()).isEqualTo(movie);
+            assertThat(director1.getName()).isEqualTo(director.getName());
+            assertThat(director1.getAge()).isEqualTo(director.getAge());
+            assertThat(director1.getId()).isEqualTo(director.getId());
+        }
+
+        @Test
+        @DisplayName("Should convert an embedded class from element list")
+        void shouldConvertEmbeddedClassFromElementList() {
+            Movie movie = new Movie("Matrix", 2012, singleton("Actor"));
+            Director director = Director.builderDirector().withAge(12)
+                    .withId(12)
+                    .withName("Otavio")
+                    .withPhones(asList("234", "2342")).withMovie(movie).build();
+
+            var entity = converter.toCommunication(director);
+            entity.remove("movie");
+            entity.add(Element.of("movie", Arrays.asList(Element.of("title", "Matrix"),
+                    Element.of("year", 2012), Element.of("actors", singleton("Actor")))));
+            Director director1 = converter.toEntity(entity);
+
+            assertThat(director1.getMovie()).isEqualTo(movie);
+            assertThat(director1.getName()).isEqualTo(director.getName());
+            assertThat(director1.getAge()).isEqualTo(director.getAge());
+            assertThat(director1.getId()).isEqualTo(director.getId());
+        }
+
+        @Test
+        @DisplayName("Should convert an embedded class from map")
+        void shouldConvertEmbeddedClassFromMap() {
+            Movie movie = new Movie("Matrix", 2012, singleton("Actor"));
+            Director director = Director.builderDirector().withAge(12)
+                    .withId(12)
+                    .withName("Otavio")
+                    .withPhones(asList("234", "2342")).withMovie(movie).build();
+
+            var entity = converter.toCommunication(director);
+            entity.remove("movie");
+            Map<String, Object> map = new HashMap<>();
+            map.put("title", "Matrix");
+            map.put("year", 2012);
+            map.put("actors", singleton("Actor"));
+
+            entity.add(Element.of("movie", map));
+            Director director1 = converter.toEntity(entity);
+
+            assertThat(director1.getMovie()).isEqualTo(movie);
+            assertThat(director1.getName()).isEqualTo(director.getName());
+            assertThat(director1.getAge()).isEqualTo(director.getAge());
+            assertThat(director1.getId()).isEqualTo(director.getId());
+        }
+
+        @Test
+        @DisplayName("Should convert To Column When has Converter")
+        void shouldConvertToColumnWhenHaConverter() {
+            Worker worker = new Worker();
+            Job job = new Job();
+            job.setCity("Sao Paulo");
+            job.setDescription("Java Developer");
+            worker.setName("Bob");
+            worker.setSalary(new Money("BRL", BigDecimal.TEN));
+            worker.setJob(job);
+            var entity = converter.toCommunication(worker);
+            assertThat(entity.name()).isEqualTo("Worker");
+            assertThat(entity.find("name").get().get()).isEqualTo("Bob");
+            assertThat(entity.find("city").get().get()).isEqualTo("Sao Paulo");
+            assertThat(entity.find("description").get().get()).isEqualTo("Java Developer");
+            assertThat(entity.find("money").get().get()).isEqualTo("BRL 10");
+        }
+
+        @Test
+        @DisplayName("Should convert To Entity When Has Converter")
+        void shouldConvertToEntityWhenHasConverter() {
+            Worker worker = new Worker();
+            Job job = new Job();
+            job.setCity("Sao Paulo");
+            job.setDescription("Java Developer");
+            worker.setName("Bob");
+            worker.setSalary(new Money("BRL", BigDecimal.TEN));
+            worker.setJob(job);
+            var entity = converter.toCommunication(worker);
+            Worker worker1 = converter.toEntity(entity);
+            assertThat(worker1.getSalary()).isEqualTo(worker.getSalary());
+            assertThat(worker1.getJob().getCity()).isEqualTo(job.getCity());
+            assertThat(worker1.getJob().getDescription()).isEqualTo(job.getDescription());
+        }
+
+        @Test
+        @DisplayName("Should convert Embeddable Lazily")
+        void shouldConvertEmbeddableLazily() {
+            var entity = CommunicationEntity.of("Worker");
+            entity.add("name", "Otavio");
+            entity.add("money", "BRL 10");
+
+            Worker worker = converter.toEntity(entity);
+            assertThat(worker.getName()).isEqualTo("Otavio");
+            assertThat(worker.getSalary()).isEqualTo(new Money("BRL", BigDecimal.TEN));
+            assertThat(worker.getJob()).isNull();
+
+        }
+
+
+        @Test
+        @DisplayName("Should convert To List Embeddable")
+        void shouldConvertToListEmbeddable() {
+            AppointmentBook appointmentBook = new AppointmentBook("ids");
+            appointmentBook.add(Contact.builder().withType(ContactType.EMAIL)
+                    .withName("Ada").withInformation("ada@lovelace.com").build());
+            appointmentBook.add(Contact.builder().withType(ContactType.MOBILE)
+                    .withName("Ada").withInformation("11 1231231 123").build());
+            appointmentBook.add(Contact.builder().withType(ContactType.PHONE)
+                    .withName("Ada").withInformation("12 123 1231 123123").build());
+
+            var entity = converter.toCommunication(appointmentBook);
+            Element contacts = entity.find("contacts").get();
+            assertThat(appointmentBook.getId()).isEqualTo("ids");
+            List<List<Element>> columns = (List<List<Element>>) contacts.get();
+
+            assertThat(columns.stream().flatMap(Collection::stream)
+                    .filter(c -> c.name().equals("contact_name"))
+                    .count()).isEqualTo(3L);
+        }
+
+        @Test
+        @DisplayName("Should convert From List Embeddable")
+        void shouldConvertFromListEmbeddable() {
+            var entity = CommunicationEntity.of("AppointmentBook");
+            entity.add(Element.of("_id", "ids"));
+            List<List<Element>> columns = new ArrayList<>();
+
+            columns.add(asList(Element.of("contact_name", "Ada"), Element.of("type", ContactType.EMAIL),
+                    Element.of("information", "ada@lovelace.com")));
+
+            columns.add(asList(Element.of("contact_name", "Ada"), Element.of("type", ContactType.MOBILE),
+                    Element.of("information", "11 1231231 123")));
+
+            columns.add(asList(Element.of("contact_name", "Ada"), Element.of("type", ContactType.PHONE),
+                    Element.of("information", "phone")));
+
+            entity.add(Element.of("contacts", columns));
+
+            AppointmentBook appointmentBook = converter.toEntity(entity);
+
+            List<Contact> contacts = appointmentBook.getContacts();
+            assertThat(appointmentBook.getId()).isEqualTo("ids");
+            assertThat(contacts.stream().map(Contact::getName).distinct().findFirst().get()).isEqualTo("Ada");
+
+        }
+
+
+        @Test
+        @DisplayName("Should convert Sub Entity")
+        void shouldConvertSubEntity() {
+            ZipCode zipcode = new ZipCode();
+            zipcode.setZip("12321");
+            zipcode.setPlusFour("1234");
+
+            Address address = new Address();
+            address.setCity("Salvador");
+            address.setState("Bahia");
+            address.setStreet("Rua Engenheiro Jose Anasoh");
+            address.setZipCode(zipcode);
+
+            var columnEntity = converter.toCommunication(address);
+            List<Element> columns = columnEntity.elements();
+            assertThat(columnEntity.name()).isEqualTo("Address");
+            assertThat(columns.size()).isEqualTo(4);
+            List<Element> zip = columnEntity.find("zipCode").map(d -> d.get(new TypeReference<List<Element>>() {
+            })).orElse(Collections.emptyList());
+
+            assertThat(getValue(columnEntity.find("street"))).isEqualTo("Rua Engenheiro Jose Anasoh");
+            assertThat(getValue(columnEntity.find("city"))).isEqualTo("Salvador");
+            assertThat(getValue(columnEntity.find("state"))).isEqualTo("Bahia");
+            assertThat(getValue(zip.stream().filter(d -> d.name().equals("zip")).findFirst())).isEqualTo("12321");
+            assertThat(getValue(zip.stream().filter(d -> d.name().equals("plusFour")).findFirst())).isEqualTo("1234");
+        }
+
+        @Test
+        @DisplayName("Should convert Column In Sub Entity")
+        void shouldConvertColumnInSubEntity() {
+
+            var entity = CommunicationEntity.of("Address");
+
+            entity.add(Element.of("street", "Rua Engenheiro Jose Anasoh"));
+            entity.add(Element.of("city", "Salvador"));
+            entity.add(Element.of("state", "Bahia"));
+            entity.add(Element.of("zipCode", Arrays.asList(
+                    Element.of("zip", "12321"),
+                    Element.of("plusFour", "1234"))));
+            Address address = converter.toEntity(entity);
+
+            assertThat(address.getStreet()).isEqualTo("Rua Engenheiro Jose Anasoh");
+            assertThat(address.getCity()).isEqualTo("Salvador");
+            assertThat(address.getState()).isEqualTo("Bahia");
+            assertThat(address.getZipCode().getZip()).isEqualTo("12321");
+            assertThat(address.getZipCode().getPlusFour()).isEqualTo("1234");
+
+        }
+
+        @Test
+        @DisplayName("Should return Null When There Is Not Sub Entity")
+        void shouldReturnNullWhenThereIsNotSubEntity() {
+            var entity = CommunicationEntity.of("Address");
+
+            entity.add(Element.of("street", "Rua Engenheiro Jose Anasoh"));
+            entity.add(Element.of("city", "Salvador"));
+            entity.add(Element.of("state", "Bahia"));
+            entity.add(Element.of("zip", "12321"));
+            entity.add(Element.of("plusFour", "1234"));
+
+            Address address = converter.toEntity(entity);
+
+            assertThat(address.getStreet()).isEqualTo("Rua Engenheiro Jose Anasoh");
+            assertThat(address.getCity()).isEqualTo("Salvador");
+            assertThat(address.getState()).isEqualTo("Bahia");
+            assertThat(address.getZipCode()).isNull();
+        }
+
+        @Test
+        @DisplayName("Should convert And does not Use Unmodifiable Collection")
+        void shouldConvertAndDoNotUseUnmodifiableCollection() {
+            var entity = CommunicationEntity.of("vendors");
+            entity.add("name", "name");
+            entity.add("prefixes", Arrays.asList("value", "value2"));
+
+            Vendor vendor = converter.toEntity(entity);
+            vendor.add("value3");
+
+            assertThat(vendor.getPrefixes().size()).isEqualTo(3);
+
+        }
+
+        @Test
+        @DisplayName("Should convert Entity To Document With Array")
+        void shouldConvertEntityToDocumentWithArray() {
+            byte[] contents = {1, 2, 3, 4, 5, 6};
+
+            var entity = CommunicationEntity.of("download");
+            entity.add("_id", 1L);
+            entity.add("contents", contents);
+
+            Download download = converter.toEntity(entity);
+            assertThat(download.getId()).isEqualTo(1L);
+            assertThat(download.getContents()).containsExactly(contents);
+        }
+
+        @Test
+        @DisplayName("Should convert Document To Entity With Array")
+        void shouldConvertDocumentToEntityWithArray() {
+            byte[] contents = {1, 2, 3, 4, 5, 6};
+
+            Download download = new Download();
+            download.setId(1L);
+            download.setContents(contents);
+
+            var entity = converter.toCommunication(download);
+
+            assertThat(entity.find("_id").get().get()).isEqualTo(1L);
+            final byte[] bytes = entity.find("contents").map(v -> v.get(byte[].class)).orElse(new byte[0]);
+            assertThat(bytes).containsExactly(contents);
+        }
+
+        @Test
+        @DisplayName("Should create user scope from a collection")
+        void shouldCreateUserScope() {
+            var entity = CommunicationEntity.of("UserScope");
+            entity.add("_id", "userName");
+            entity.add("scope", "scope");
+            entity.add("properties", Collections.singletonList(Element.of("halo", "weld")));
+
+            UserScope user = converter.toEntity(entity);
+            assertThat(user).isNotNull();
+            assertThat(user.getUserName()).isEqualTo("userName");
+            assertThat(user.getScope()).isEqualTo("scope");
+            assertThat(user.getProperties()).isEqualTo(Collections.singletonMap("halo", "weld"));
+
+        }
+
+        @Test
+        @DisplayName("Should create user scope from an element")
+        void shouldCreateUserScopeFromElement() {
+            var entity = CommunicationEntity.of("UserScope");
+            entity.add("_id", "userName");
+            entity.add("scope", "scope");
+            entity.add("properties", Element.of("halo", "weld"));
+
+            UserScope user = converter.toEntity(entity);
+            assertThat(user).isNotNull();
+            assertThat(user.getUserName()).isEqualTo("userName");
+            assertThat(user.getScope()).isEqualTo("scope");
+            assertThat(user.getProperties()).isEqualTo(Collections.singletonMap("halo", "weld"));
+
+        }
+
+        @Test
+        @DisplayName("Should create Lazily Entity")
+        void shouldCreateLazilyEntity() {
+            var entity = CommunicationEntity.of("Citizen");
+            entity.add("id", "10");
+            entity.add("name", "Salvador");
+
+            Citizen citizen = converter.toEntity(entity);
+            assertThat(citizen).isNotNull();
+            assertThat(citizen.getCity()).isNull();
+        }
+
+        @Test
+        @DisplayName("Should convert Group Embeddable")
+        void shouldConvertGroupEmbeddable(){
+            CommunicationEntity entity = CommunicationEntity.of("Wine");
+            entity.add("_id", "id");
+            entity.add("name", "Vin Blanc");
+            entity.add("factory", List.of(Element.of("name", "Napa Valley Factory"),
+                    Element.of("location", "Napa Valley")));
+
+            Wine wine = converter.toEntity(entity);
+
+            assertSoftly(soft ->{
+                WineFactory factory = wine.getFactory();
+                soft.assertThat(wine).as("wine").isNotNull();
+                soft.assertThat(wine.getId()).as("wine id").isEqualTo("id");
+                soft.assertThat(wine.getName()).as("wine name").isEqualTo("Vin Blanc");
+                soft.assertThat(factory).as("wine factory").isNotNull();
+                soft.assertThat(factory.getName()).as("factory name").isEqualTo("Napa Valley Factory");
+                soft.assertThat(factory.getLocation()).as("factory location").isEqualTo("Napa Valley");
+            });
+        }
+
+        @Test
+        @DisplayName("Should convert Group Embeddable To Communication")
+        void shouldConvertGroupEmbeddableToCommunication(){
+
+            Wine wine = Wine.of("id", "Vin Blanc", WineFactory.of("Napa Valley Factory", "Napa Valley"));
+
+
+            var communication = converter.toCommunication(wine);
+
+            assertSoftly(soft ->{
+                soft.assertThat(communication).as("communication entity").isNotNull();
+                soft.assertThat(communication.name()).as("entity name").isEqualTo("Wine");
+                soft.assertThat(communication.find("_id").orElseThrow().get()).as("identifier element").isEqualTo("id");
+                soft.assertThat(communication.find("name").orElseThrow().get()).as("name element").isEqualTo("Vin Blanc");
+                communication.find("factory").ifPresent(e -> {
+                    List<Element> elements = e.get(new TypeReference<>(){});
+                    soft.assertThat(elements).as("factory elements").hasSize(2);
+                    soft.assertThat(elements.stream().filter(c -> "name".equals(c.name())).findFirst().orElseThrow().get())
+                            .as("factory name element")
+                            .isEqualTo("Napa Valley Factory");
+                    soft.assertThat(elements.stream().filter(c -> "location".equals(c.name())).findFirst().orElseThrow().get())
+                            .as("factory location element")
+                            .isEqualTo("Napa Valley");
+                });
+
+            });
+        }
+
     }
 
     private Object getValue(Optional<Element> column) {

--- a/jnosql-lite/mapping-lite-document-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/DocumentEntityConverterInheritanceTest.java
+++ b/jnosql-lite/mapping-lite-document-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/DocumentEntityConverterInheritanceTest.java
@@ -36,7 +36,8 @@ import org.eclipse.jnosql.mapping.semistructured.EntityConverter;
 import org.jboss.weld.junit5.auto.AddExtensions;
 import org.jboss.weld.junit5.auto.AddPackages;
 import org.jboss.weld.junit5.auto.EnableAutoWeld;
-import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
@@ -46,8 +47,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 @EnableAutoWeld
 @AddPackages(value = {Converters.class, EntityConverter.class, DocumentTemplate.class})
@@ -58,375 +58,400 @@ class DocumentEntityConverterInheritanceTest {
     @Inject
     private EntityConverter converter;
 
-    @Test
-    void shouldConvertProjectToSmallProject() {
-        var entity = CommunicationEntity.of("Project");
-        entity.add("_id", "Small Project");
-        entity.add("investor", "Otavio Santana");
-        entity.add("size", "Small");
-        Project project = this.converter.toEntity(entity);
-        assertEquals("Small Project", project.getName());
-        assertEquals(SmallProject.class, project.getClass());
-        SmallProject smallProject = (SmallProject) project;
-        assertEquals("Otavio Santana", smallProject.getInvestor());
-    }
+    @Nested
+    @DisplayName("When converting inherited entities")
+    class WhenTheConversion {
 
-    @Test
-    void shouldConvertProjectToLargeProject() {
-        var entity = CommunicationEntity.of("Project");
-        entity.add("_id", "Large Project");
-        entity.add("budget", BigDecimal.TEN);
-        entity.add("size", "Large");
-        Project project = this.converter.toEntity(entity);
-        assertEquals("Large Project", project.getName());
-        assertEquals(LargeProject.class, project.getClass());
-        LargeProject smallProject = (LargeProject) project;
-        assertEquals(BigDecimal.TEN, smallProject.getBudget());
-    }
+        @Test
+        @DisplayName("Should convert project to small project")
+        void shouldConvertProjectToSmallProject() {
+            var entity = CommunicationEntity.of("Project");
+            entity.add("_id", "Small Project");
+            entity.add("investor", "Otavio Santana");
+            entity.add("size", "Small");
+            Project project = converter.toEntity(entity);
+            assertThat(project.getName()).isEqualTo("Small Project");
+            assertThat(project.getClass()).isEqualTo(SmallProject.class);
+            SmallProject smallProject = (SmallProject) project;
+            assertThat(smallProject.getInvestor()).isEqualTo("Otavio Santana");
+        }
 
-    @Test
-    void shouldConvertLargeProjectToCommunicationEntity() {
-        LargeProject project = new LargeProject();
-        project.setName("Large Project");
-        project.setBudget(BigDecimal.TEN);
-        var entity = this.converter.toCommunication(project);
-        assertNotNull(entity);
-        assertEquals("Project", entity.name());
-        assertEquals(project.getName(), entity.find("_id", String.class).get());
-        assertEquals(project.getBudget(), entity.find("budget", BigDecimal.class).get());
-        assertEquals("Large", entity.find("size", String.class).get());
-    }
+        @Test
+        @DisplayName("Should convert project to large project")
+        void shouldConvertProjectToLargeProject() {
+            var entity = CommunicationEntity.of("Project");
+            entity.add("_id", "Large Project");
+            entity.add("budget", BigDecimal.TEN);
+            entity.add("size", "Large");
+            Project project = converter.toEntity(entity);
+            assertThat(project.getName()).isEqualTo("Large Project");
+            assertThat(project.getClass()).isEqualTo(LargeProject.class);
+            LargeProject smallProject = (LargeProject) project;
+            assertThat(smallProject.getBudget()).isEqualTo(BigDecimal.TEN);
+        }
 
-    @Test
-    void shouldConvertSmallProjectToCommunicationEntity() {
-        SmallProject project = new SmallProject();
-        project.setName("Small Project");
-        project.setInvestor("Otavio Santana");
-        var entity = this.converter.toCommunication(project);
-        assertNotNull(entity);
-        assertEquals("Project", entity.name());
-        assertEquals(project.getName(), entity.find("_id", String.class).get());
-        assertEquals(project.getInvestor(), entity.find("investor", String.class).get());
-        assertEquals("Small", entity.find("size", String.class).get());
-    }
+        @Test
+        @DisplayName("Should convert large project to communication entity")
+        void shouldConvertLargeProjectToCommunicationEntity() {
+            LargeProject project = new LargeProject();
+            project.setName("Large Project");
+            project.setBudget(BigDecimal.TEN);
+            var entity = converter.toCommunication(project);
+            assertThat(entity).isNotNull();
+            assertThat(entity.name()).isEqualTo("Project");
+            assertThat(entity.find("_id", String.class).get()).isEqualTo(project.getName());
+            assertThat(entity.find("budget", BigDecimal.class).get()).isEqualTo(project.getBudget());
+            assertThat(entity.find("size", String.class).get()).isEqualTo("Large");
+        }
 
-    @Test
-    void shouldConvertProject() {
-        var entity = CommunicationEntity.of("Project");
-        entity.add("_id", "Project");
-        entity.add("size", "Project");
-        Project project = this.converter.toEntity(entity);
-        assertEquals("Project", project.getName());
-    }
+        @Test
+        @DisplayName("Should convert small project to communication entity")
+        void shouldConvertSmallProjectToCommunicationEntity() {
+            SmallProject project = new SmallProject();
+            project.setName("Small Project");
+            project.setInvestor("Otavio Santana");
+            var entity = converter.toCommunication(project);
+            assertThat(entity).isNotNull();
+            assertThat(entity.name()).isEqualTo("Project");
+            assertThat(entity.find("_id", String.class).get()).isEqualTo(project.getName());
+            assertThat(entity.find("investor", String.class).get()).isEqualTo(project.getInvestor());
+            assertThat(entity.find("size", String.class).get()).isEqualTo("Small");
+        }
 
-    @Test
-    void shouldConvertProjectToCommunicationEntity() {
-        Project project = new Project();
-        project.setName("Large Project");
-        var entity = this.converter.toCommunication(project);
-        assertNotNull(entity);
-        assertEquals("Project", entity.name());
-        assertEquals(project.getName(), entity.find("_id", String.class).get());
-        assertEquals("Project", entity.find("size", String.class).get());
-    }
+        @Test
+        @DisplayName("Should convert project")
+        void shouldConvertProject() {
+            var entity = CommunicationEntity.of("Project");
+            entity.add("_id", "Project");
+            entity.add("size", "Project");
+            Project project = converter.toEntity(entity);
+            assertThat(project.getName()).isEqualTo("Project");
+        }
 
-    @Test
-    void shouldConvertDocumentEntityToSocialMedia(){
-        LocalDate date = LocalDate.now();
-        var entity = CommunicationEntity.of("Notification");
-        entity.add("_id", 100L);
-        entity.add("name", "Social Media");
-        entity.add("nickname", "otaviojava");
-        entity.add("createdOn",date);
-        entity.add("dtype", SocialMediaNotification.class.getSimpleName());
-        SocialMediaNotification notification = this.converter.toEntity(entity);
-        assertEquals(100L, notification.getId());
-        assertEquals("Social Media", notification.getName());
-        assertEquals("otaviojava", notification.getNickname());
-        assertEquals(date, notification.getCreatedOn());
-    }
+        @Test
+        @DisplayName("Should convert project to communication entity")
+        void shouldConvertProjectToCommunicationEntity() {
+            Project project = new Project();
+            project.setName("Large Project");
+            var entity = converter.toCommunication(project);
+            assertThat(entity).isNotNull();
+            assertThat(entity.name()).isEqualTo("Project");
+            assertThat(entity.find("_id", String.class).get()).isEqualTo(project.getName());
+            assertThat(entity.find("size", String.class).get()).isEqualTo("Project");
+        }
 
-    @Test
-    void shouldConvertDocumentEntityToSms(){
-        LocalDate date = LocalDate.now();
-        var entity = CommunicationEntity.of("Notification");
-        entity.add("_id", 100L);
-        entity.add("name", "SMS Notification");
-        entity.add("phone", "+351987654123");
-        entity.add("createdOn", date);
-        entity.add("dtype", "SMS");
-        SmsNotification notification = this.converter.toEntity(entity);
-        Assertions.assertEquals(100L, notification.getId());
-        Assertions.assertEquals("SMS Notification", notification.getName());
-        Assertions.assertEquals("+351987654123", notification.getPhone());
-        assertEquals(date, notification.getCreatedOn());
-    }
+        @Test
+        @DisplayName("Should convert document entity to social media notification")
+        void shouldConvertDocumentEntityToSocialMedia(){
+            LocalDate date = LocalDate.now();
+            var entity = CommunicationEntity.of("Notification");
+            entity.add("_id", 100L);
+            entity.add("name", "Social Media");
+            entity.add("nickname", "otaviojava");
+            entity.add("createdOn",date);
+            entity.add("dtype", SocialMediaNotification.class.getSimpleName());
+            SocialMediaNotification notification = converter.toEntity(entity);
+            assertThat(notification.getId()).isEqualTo(100L);
+            assertThat(notification.getName()).isEqualTo("Social Media");
+            assertThat(notification.getNickname()).isEqualTo("otaviojava");
+            assertThat(notification.getCreatedOn()).isEqualTo(date);
+        }
 
-    @Test
-    void shouldConvertDocumentEntityToEmail(){
-        LocalDate date = LocalDate.now();
-        var entity = CommunicationEntity.of("Notification");
-        entity.add("_id", 100L);
-        entity.add("name", "Email Notification");
-        entity.add("email", "otavio@otavio.test");
-        entity.add("createdOn", date);
-        entity.add("dtype", "Email");
-        EmailNotification notification = this.converter.toEntity(entity);
-        Assertions.assertEquals(100L, notification.getId());
-        Assertions.assertEquals("Email Notification", notification.getName());
-        Assertions.assertEquals("otavio@otavio.test", notification.getEmail());
-        assertEquals(date, notification.getCreatedOn());
-    }
+        @Test
+        @DisplayName("Should convert document entity to SMS notification")
+        void shouldConvertDocumentEntityToSms(){
+            LocalDate date = LocalDate.now();
+            var entity = CommunicationEntity.of("Notification");
+            entity.add("_id", 100L);
+            entity.add("name", "SMS Notification");
+            entity.add("phone", "+351987654123");
+            entity.add("createdOn", date);
+            entity.add("dtype", "SMS");
+            SmsNotification notification = converter.toEntity(entity);
+            assertThat(notification.getId()).isEqualTo(100L);
+            assertThat(notification.getName()).isEqualTo("SMS Notification");
+            assertThat(notification.getPhone()).isEqualTo("+351987654123");
+            assertThat(notification.getCreatedOn()).isEqualTo(date);
+        }
 
-    @Test
-    void shouldConvertSocialMediaToCommunicationEntity(){
-        SocialMediaNotification notification = new SocialMediaNotification();
-        notification.setId(100L);
-        notification.setName("Social Media");
-        notification.setCreatedOn(LocalDate.now());
-        notification.setNickname("otaviojava");
-        var entity = this.converter.toCommunication(notification);
-        assertNotNull(entity);
-        assertEquals("Notification", entity.name());
-        assertEquals(notification.getId(), entity.find("_id", Long.class).get());
-        assertEquals(notification.getName(), entity.find("name", String.class).get());
-        assertEquals(notification.getNickname(), entity.find("nickname", String.class).get());
-        assertEquals(notification.getCreatedOn(), entity.find("createdOn", LocalDate.class).get());
-    }
+        @Test
+        @DisplayName("Should convert document entity to email notification")
+        void shouldConvertDocumentEntityToEmail(){
+            LocalDate date = LocalDate.now();
+            var entity = CommunicationEntity.of("Notification");
+            entity.add("_id", 100L);
+            entity.add("name", "Email Notification");
+            entity.add("email", "otavio@otavio.test");
+            entity.add("createdOn", date);
+            entity.add("dtype", "Email");
+            EmailNotification notification = converter.toEntity(entity);
+            assertThat(notification.getId()).isEqualTo(100L);
+            assertThat(notification.getName()).isEqualTo("Email Notification");
+            assertThat(notification.getEmail()).isEqualTo("otavio@otavio.test");
+            assertThat(notification.getCreatedOn()).isEqualTo(date);
+        }
 
-    @Test
-    void shouldConvertSmsToCommunicationEntity(){
-        SmsNotification notification = new SmsNotification();
-        notification.setId(100L);
-        notification.setName("SMS");
-        notification.setCreatedOn(LocalDate.now());
-        notification.setPhone("+351123456987");
-        var entity = this.converter.toCommunication(notification);
-        assertNotNull(entity);
-        assertEquals("Notification", entity.name());
-        assertEquals(notification.getId(), entity.find("_id", Long.class).get());
-        assertEquals(notification.getName(), entity.find("name", String.class).get());
-        assertEquals(notification.getPhone(), entity.find("phone", String.class).get());
-        assertEquals(notification.getCreatedOn(), entity.find("createdOn", LocalDate.class).get());
-    }
+        @Test
+        @DisplayName("Should convert social media notification to communication entity")
+        void shouldConvertSocialMediaToCommunicationEntity(){
+            SocialMediaNotification notification = new SocialMediaNotification();
+            notification.setId(100L);
+            notification.setName("Social Media");
+            notification.setCreatedOn(LocalDate.now());
+            notification.setNickname("otaviojava");
+            var entity = converter.toCommunication(notification);
+            assertThat(entity).isNotNull();
+            assertThat(entity.name()).isEqualTo("Notification");
+            assertThat(entity.find("_id", Long.class).get()).isEqualTo(notification.getId());
+            assertThat(entity.find("name", String.class).get()).isEqualTo(notification.getName());
+            assertThat(entity.find("nickname", String.class).get()).isEqualTo(notification.getNickname());
+            assertThat(entity.find("createdOn", LocalDate.class).get()).isEqualTo(notification.getCreatedOn());
+        }
 
-    @Test
-    void shouldConvertEmailToCommunicationEntity(){
-        EmailNotification notification = new EmailNotification();
-        notification.setId(100L);
-        notification.setName("Email Media");
-        notification.setCreatedOn(LocalDate.now());
-        notification.setEmail("otavio@otavio.test.com");
-        var entity = this.converter.toCommunication(notification);
-        assertNotNull(entity);
-        assertEquals("Notification", entity.name());
-        assertEquals(notification.getId(), entity.find("_id", Long.class).get());
-        assertEquals(notification.getName(), entity.find("name", String.class).get());
-        assertEquals(notification.getEmail(), entity.find("email", String.class).get());
-        assertEquals(notification.getCreatedOn(), entity.find("createdOn", LocalDate.class).get());
-    }
+        @Test
+        @DisplayName("Should convert SMS notification to communication entity")
+        void shouldConvertSmsToCommunicationEntity(){
+            SmsNotification notification = new SmsNotification();
+            notification.setId(100L);
+            notification.setName("SMS");
+            notification.setCreatedOn(LocalDate.now());
+            notification.setPhone("+351123456987");
+            var entity = converter.toCommunication(notification);
+            assertThat(entity).isNotNull();
+            assertThat(entity.name()).isEqualTo("Notification");
+            assertThat(entity.find("_id", Long.class).get()).isEqualTo(notification.getId());
+            assertThat(entity.find("name", String.class).get()).isEqualTo(notification.getName());
+            assertThat(entity.find("phone", String.class).get()).isEqualTo(notification.getPhone());
+            assertThat(entity.find("createdOn", LocalDate.class).get()).isEqualTo(notification.getCreatedOn());
+        }
 
-    @Test
-    void shouldReturnErrorWhenConvertMissingDocument(){
-        LocalDate date = LocalDate.now();
-        var entity = CommunicationEntity.of("Notification");
-        entity.add("_id", 100L);
-        entity.add("name", "SMS Notification");
-        entity.add("phone", "+351987654123");
-        entity.add("createdOn", date);
-        Assertions.assertThrows(MappingException.class, ()-> this.converter.toEntity(entity));
-    }
+        @Test
+        @DisplayName("Should convert email notification to communication entity")
+        void shouldConvertEmailToCommunicationEntity(){
+            EmailNotification notification = new EmailNotification();
+            notification.setId(100L);
+            notification.setName("Email Media");
+            notification.setCreatedOn(LocalDate.now());
+            notification.setEmail("otavio@otavio.test.com");
+            var entity = converter.toCommunication(notification);
+            assertThat(entity).isNotNull();
+            assertThat(entity.name()).isEqualTo("Notification");
+            assertThat(entity.find("_id", Long.class).get()).isEqualTo(notification.getId());
+            assertThat(entity.find("name", String.class).get()).isEqualTo(notification.getName());
+            assertThat(entity.find("email", String.class).get()).isEqualTo(notification.getEmail());
+            assertThat(entity.find("createdOn", LocalDate.class).get()).isEqualTo(notification.getCreatedOn());
+        }
 
-    @Test
-    void shouldReturnErrorWhenMismatchField() {
-        LocalDate date = LocalDate.now();
-        var entity = CommunicationEntity.of("Notification");
-        entity.add("_id", 100L);
-        entity.add("name", "Email Notification");
-        entity.add("email", "otavio@otavio.test");
-        entity.add("createdOn", date);
-        entity.add("dtype", "Wrong");
-        Assertions.assertThrows(MappingException.class, ()-> this.converter.toEntity(entity));
-    }
+        @Test
+        @DisplayName("Should return an error when document discriminator is missing")
+        void shouldReturnErrorWhenConvertMissingDocument(){
+            LocalDate date = LocalDate.now();
+            var entity = CommunicationEntity.of("Notification");
+            entity.add("_id", 100L);
+            entity.add("name", "SMS Notification");
+            entity.add("phone", "+351987654123");
+            entity.add("createdOn", date);
+            assertThatExceptionOfType(MappingException.class).isThrownBy(() -> converter.toEntity(entity));
+        }
+
+        @Test
+        @DisplayName("Should return an error when discriminator does not match")
+        void shouldReturnErrorWhenMismatchField() {
+            LocalDate date = LocalDate.now();
+            var entity = CommunicationEntity.of("Notification");
+            entity.add("_id", 100L);
+            entity.add("name", "Email Notification");
+            entity.add("email", "otavio@otavio.test");
+            entity.add("createdOn", date);
+            entity.add("dtype", "Wrong");
+            assertThatExceptionOfType(MappingException.class).isThrownBy(() -> converter.toEntity(entity));
+        }
 
 
 
-    @Test
-    void shouldConvertCommunicationNotificationReaderEmail() {
-        var entity = CommunicationEntity.of("NotificationReader");
-        entity.add("_id", "poli");
-        entity.add("name", "Poliana Santana");
-        entity.add("notification", Arrays.asList(
-                Element.of("_id", 10L),
-                Element.of("name", "News"),
-                Element.of("email", "otavio@email.com"),
-                Element.of("_id", LocalDate.now()),
-                Element.of("dtype", "Email")
-        ));
+        @Test
+        @DisplayName("Should convert notification reader with email notification")
+        void shouldConvertCommunicationNotificationReaderEmail() {
+            var entity = CommunicationEntity.of("NotificationReader");
+            entity.add("_id", "poli");
+            entity.add("name", "Poliana Santana");
+            entity.add("notification", Arrays.asList(
+                    Element.of("_id", 10L),
+                    Element.of("name", "News"),
+                    Element.of("email", "otavio@email.com"),
+                    Element.of("_id", LocalDate.now()),
+                    Element.of("dtype", "Email")
+            ));
 
-        NotificationReader notificationReader = converter.toEntity(entity);
-        assertNotNull(notificationReader);
-        Assertions.assertEquals("poli", notificationReader.getNickname());
-        Assertions.assertEquals("Poliana Santana", notificationReader.getName());
-        Notification notification = notificationReader.getNotification();
-        assertNotNull(notification);
-        Assertions.assertEquals(EmailNotification.class, notification.getClass());
-        EmailNotification email = (EmailNotification) notification;
-        Assertions.assertEquals(10L, email.getId());
-        Assertions.assertEquals("News", email.getName());
-        Assertions.assertEquals("otavio@email.com", email.getEmail());
-    }
+            NotificationReader notificationReader = converter.toEntity(entity);
+            assertThat(notificationReader).isNotNull();
+            assertThat(notificationReader.getNickname()).isEqualTo("poli");
+            assertThat(notificationReader.getName()).isEqualTo("Poliana Santana");
+            Notification notification = notificationReader.getNotification();
+            assertThat(notification).isNotNull();
+            assertThat(notification.getClass()).isEqualTo(EmailNotification.class);
+            EmailNotification email = (EmailNotification) notification;
+            assertThat(email.getId()).isEqualTo(10L);
+            assertThat(email.getName()).isEqualTo("News");
+            assertThat(email.getEmail()).isEqualTo("otavio@email.com");
+        }
 
-    @Test
-    void shouldConvertCommunicationNotificationReaderSms() {
-        var entity = CommunicationEntity.of("NotificationReader");
-        entity.add("_id", "poli");
-        entity.add("name", "Poliana Santana");
-        entity.add("notification", Arrays.asList(
-                Element.of("_id", 10L),
-                Element.of("name", "News"),
-                Element.of("phone", "123456789"),
-                Element.of("_id", LocalDate.now()),
-                Element.of("dtype", "SMS")
-        ));
+        @Test
+        @DisplayName("Should convert notification reader with SMS notification")
+        void shouldConvertCommunicationNotificationReaderSms() {
+            var entity = CommunicationEntity.of("NotificationReader");
+            entity.add("_id", "poli");
+            entity.add("name", "Poliana Santana");
+            entity.add("notification", Arrays.asList(
+                    Element.of("_id", 10L),
+                    Element.of("name", "News"),
+                    Element.of("phone", "123456789"),
+                    Element.of("_id", LocalDate.now()),
+                    Element.of("dtype", "SMS")
+            ));
 
-        NotificationReader notificationReader = converter.toEntity(entity);
-        assertNotNull(notificationReader);
-        Assertions.assertEquals("poli", notificationReader.getNickname());
-        Assertions.assertEquals("Poliana Santana", notificationReader.getName());
-        Notification notification = notificationReader.getNotification();
-        assertNotNull(notification);
-        Assertions.assertEquals(SmsNotification.class, notification.getClass());
-        SmsNotification sms = (SmsNotification) notification;
-        Assertions.assertEquals(10L, sms.getId());
-        Assertions.assertEquals("News", sms.getName());
-        Assertions.assertEquals("123456789", sms.getPhone());
-    }
+            NotificationReader notificationReader = converter.toEntity(entity);
+            assertThat(notificationReader).isNotNull();
+            assertThat(notificationReader.getNickname()).isEqualTo("poli");
+            assertThat(notificationReader.getName()).isEqualTo("Poliana Santana");
+            Notification notification = notificationReader.getNotification();
+            assertThat(notification).isNotNull();
+            assertThat(notification.getClass()).isEqualTo(SmsNotification.class);
+            SmsNotification sms = (SmsNotification) notification;
+            assertThat(sms.getId()).isEqualTo(10L);
+            assertThat(sms.getName()).isEqualTo("News");
+            assertThat(sms.getPhone()).isEqualTo("123456789");
+        }
 
-    @Test
-    void shouldConvertCommunicationNotificationReaderSocial() {
-        var entity = CommunicationEntity.of("NotificationReader");
-        entity.add("_id", "poli");
-        entity.add("name", "Poliana Santana");
-        entity.add("notification", Arrays.asList(
-                Element.of("_id", 10L),
-                Element.of("name", "News"),
-                Element.of("nickname", "123456789"),
-                Element.of("_id", LocalDate.now()),
-                Element.of("dtype", "SocialMediaNotification")
-        ));
+        @Test
+        @DisplayName("Should convert notification reader with social notification")
+        void shouldConvertCommunicationNotificationReaderSocial() {
+            var entity = CommunicationEntity.of("NotificationReader");
+            entity.add("_id", "poli");
+            entity.add("name", "Poliana Santana");
+            entity.add("notification", Arrays.asList(
+                    Element.of("_id", 10L),
+                    Element.of("name", "News"),
+                    Element.of("nickname", "123456789"),
+                    Element.of("_id", LocalDate.now()),
+                    Element.of("dtype", "SocialMediaNotification")
+            ));
 
-        NotificationReader notificationReader = converter.toEntity(entity);
-        assertNotNull(notificationReader);
-        Assertions.assertEquals("poli", notificationReader.getNickname());
-        Assertions.assertEquals("Poliana Santana", notificationReader.getName());
-        Notification notification = notificationReader.getNotification();
-        assertNotNull(notification);
-        Assertions.assertEquals(SocialMediaNotification.class, notification.getClass());
-        SocialMediaNotification social = (SocialMediaNotification) notification;
-        Assertions.assertEquals(10L, social.getId());
-        Assertions.assertEquals("News", social.getName());
-        Assertions.assertEquals("123456789", social.getNickname());
-    }
+            NotificationReader notificationReader = converter.toEntity(entity);
+            assertThat(notificationReader).isNotNull();
+            assertThat(notificationReader.getNickname()).isEqualTo("poli");
+            assertThat(notificationReader.getName()).isEqualTo("Poliana Santana");
+            Notification notification = notificationReader.getNotification();
+            assertThat(notification).isNotNull();
+            assertThat(notification.getClass()).isEqualTo(SocialMediaNotification.class);
+            SocialMediaNotification social = (SocialMediaNotification) notification;
+            assertThat(social.getId()).isEqualTo(10L);
+            assertThat(social.getName()).isEqualTo("News");
+            assertThat(social.getNickname()).isEqualTo("123456789");
+        }
 
-    @Test
-    void shouldConvertSocialCommunication() {
-        SocialMediaNotification notification = new SocialMediaNotification();
-        notification.setId(10L);
-        notification.setName("Ada");
-        notification.setNickname("ada.lovelace");
-        NotificationReader reader = new NotificationReader("otavio", "Otavio", notification);
+        @Test
+        @DisplayName("Should convert social notification reader to communication entity")
+        void shouldConvertSocialNotificationReaderToCommunication() {
+            SocialMediaNotification notification = new SocialMediaNotification();
+            notification.setId(10L);
+            notification.setName("Ada");
+            notification.setNickname("ada.lovelace");
+            NotificationReader reader = new NotificationReader("otavio", "Otavio", notification);
 
-        var entity = this.converter.toCommunication(reader);
-        assertNotNull(entity);
+            var entity = converter.toCommunication(reader);
+            assertThat(entity).isNotNull();
 
-        assertEquals("NotificationReader", entity.name());
-        assertEquals("otavio", entity.find("_id", String.class).get());
-        assertEquals("Otavio", entity.find("name", String.class).get());
-        List<Element> documents = entity.find("notification", new TypeReference<List<Element>>() {
-        }).get();
+            assertThat(entity.name()).isEqualTo("NotificationReader");
+            assertThat(entity.find("_id", String.class).get()).isEqualTo("otavio");
+            assertThat(entity.find("name", String.class).get()).isEqualTo("Otavio");
+            List<Element> documents = entity.find("notification", new TypeReference<List<Element>>() {
+            }).get();
 
-        assertThat(documents).contains(Element.of("_id", 10L),
-                Element.of("name", "Ada"),
-                Element.of("dtype", "SocialMediaNotification"),
-                Element.of("nickname", "ada.lovelace"));
-    }
+            assertThat(documents).contains(Element.of("_id", 10L),
+                    Element.of("name", "Ada"),
+                    Element.of("dtype", "SocialMediaNotification"),
+                    Element.of("nickname", "ada.lovelace"));
+        }
 
-    @Test
-    void shouldConvertConvertProjectManagerCommunication() {
-        LargeProject large = new LargeProject();
-        large.setBudget(BigDecimal.TEN);
-        large.setName("large");
+        @Test
+        @DisplayName("Should convert project manager to communication entity")
+        void shouldConvertProjectManagerToCommunication() {
+            LargeProject large = new LargeProject();
+            large.setBudget(BigDecimal.TEN);
+            large.setName("large");
 
-        SmallProject small = new SmallProject();
-        small.setInvestor("new investor");
-        small.setName("Start up");
+            SmallProject small = new SmallProject();
+            small.setInvestor("new investor");
+            small.setName("Start up");
 
-        List<Project> projects = new ArrayList<>();
-        projects.add(large);
-        projects.add(small);
+            List<Project> projects = new ArrayList<>();
+            projects.add(large);
+            projects.add(small);
 
-        ProjectManager manager = ProjectManager.of(10L, "manager", projects);
-        var entity = this.converter.toCommunication(manager);
-        assertNotNull(entity);
+            ProjectManager manager = ProjectManager.of(10L, "manager", projects);
+            var entity = converter.toCommunication(manager);
+            assertThat(entity).isNotNull();
 
-        assertEquals("ProjectManager", entity.name());
-        assertEquals(10L, entity.find("_id", Long.class).get());
-        assertEquals("manager", entity.find("name", String.class).get());
+            assertThat(entity.name()).isEqualTo("ProjectManager");
+            assertThat(entity.find("_id", Long.class).get()).isEqualTo(10L);
+            assertThat(entity.find("name", String.class).get()).isEqualTo("manager");
 
-        List<List<Element>> documents = (List<List<Element>>) entity.find("projects").get().get();
+            List<List<Element>> documents = (List<List<Element>>) entity.find("projects").get().get();
 
-        List<Element> largeCommunication = documents.get(0);
-        List<Element> smallCommunication = documents.get(1);
-        assertThat(largeCommunication).contains(
-                Element.of("_id", "large"),
-                Element.of("size", "Large"),
-                Element.of("budget", BigDecimal.TEN)
-        );
+            List<Element> largeCommunication = documents.get(0);
+            List<Element> smallCommunication = documents.get(1);
+            assertThat(largeCommunication).contains(
+                    Element.of("_id", "large"),
+                    Element.of("size", "Large"),
+                    Element.of("budget", BigDecimal.TEN)
+            );
 
-        assertThat(smallCommunication).contains(
-                Element.of("size", "Small"),
-                Element.of("investor", "new investor"),
-                Element.of("_id", "Start up")
-        );
+            assertThat(smallCommunication).contains(
+                    Element.of("size", "Small"),
+                    Element.of("investor", "new investor"),
+                    Element.of("_id", "Start up")
+            );
 
-    }
+        }
 
-    @Test
-    void shouldConvertConvertCommunicationProjectManager() {
-        var communication = CommunicationEntity.of("ProjectManager");
-        communication.add("_id", 10L);
-        communication.add("name", "manager");
-        List<List<Element>> documents = new ArrayList<>();
-        documents.add(Arrays.asList(
-                Element.of("_id","small-project"),
-                Element.of("size","Small"),
-                Element.of("investor","investor")
-        ));
-        documents.add(Arrays.asList(
-                Element.of("_id","large-project"),
-                Element.of("size","Large"),
-                Element.of("budget",BigDecimal.TEN)
-        ));
-        communication.add("projects", documents);
+        @Test
+        @DisplayName("Should convert communication entity to project manager")
+        void shouldConvertCommunicationToProjectManager() {
+            var communication = CommunicationEntity.of("ProjectManager");
+            communication.add("_id", 10L);
+            communication.add("name", "manager");
+            List<List<Element>> documents = new ArrayList<>();
+            documents.add(Arrays.asList(
+                    Element.of("_id","small-project"),
+                    Element.of("size","Small"),
+                    Element.of("investor","investor")
+            ));
+            documents.add(Arrays.asList(
+                    Element.of("_id","large-project"),
+                    Element.of("size","Large"),
+                    Element.of("budget",BigDecimal.TEN)
+            ));
+            communication.add("projects", documents);
 
-        ProjectManager manager = converter.toEntity(communication);
-        assertNotNull(manager);
+            ProjectManager manager = converter.toEntity(communication);
+            assertThat(manager).isNotNull();
 
-        assertEquals(10L, manager.getId());
-        assertEquals("manager", manager.getName());
+            assertThat(manager.getId()).isEqualTo(10L);
+            assertThat(manager.getName()).isEqualTo("manager");
 
-        List<Project> projects = manager.getProjects();
-        assertEquals(2, projects.size());
-        SmallProject small = (SmallProject) projects.get(0);
-        LargeProject large = (LargeProject) projects.get(1);
-        assertNotNull(small);
-        assertEquals("small-project", small.getName());
-        assertEquals("investor", small.getInvestor());
+            List<Project> projects = manager.getProjects();
+            assertThat(projects.size()).isEqualTo(2);
+            SmallProject small = (SmallProject) projects.get(0);
+            LargeProject large = (LargeProject) projects.get(1);
+            assertThat(small).isNotNull();
+            assertThat(small.getName()).isEqualTo("small-project");
+            assertThat(small.getInvestor()).isEqualTo("investor");
 
-        assertNotNull(large);
-        assertEquals("large-project", large.getName());
-        assertEquals(BigDecimal.TEN, large.getBudget());
+            assertThat(large).isNotNull();
+            assertThat(large.getName()).isEqualTo("large-project");
+            assertThat(large.getBudget()).isEqualTo(BigDecimal.TEN);
 
+        }
     }
 }

--- a/jnosql-lite/mapping-lite-document-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/DocumentEntityConverterTest.java
+++ b/jnosql-lite/mapping-lite-document-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/DocumentEntityConverterTest.java
@@ -15,7 +15,6 @@
 package org.eclipse.jnosql.lite.mapping.entities;
 
 import jakarta.inject.Inject;
-import org.assertj.core.api.SoftAssertions;
 import org.eclipse.jnosql.communication.TypeReference;
 import org.eclipse.jnosql.communication.Value;
 import org.eclipse.jnosql.communication.semistructured.CommunicationEntity;
@@ -27,8 +26,9 @@ import org.eclipse.jnosql.mapping.semistructured.EntityConverter;
 import org.jboss.weld.junit5.auto.AddExtensions;
 import org.jboss.weld.junit5.auto.AddPackages;
 import org.jboss.weld.junit5.auto.EnableAutoWeld;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
@@ -44,12 +44,9 @@ import java.util.stream.Stream;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singleton;
-import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 @EnableAutoWeld
 @AddPackages(value = {Converters.class, EntityConverter.class})
@@ -80,466 +77,500 @@ public class DocumentEntityConverterTest {
                 , Element.of("movieRating", Collections.singletonMap("JavaZone", 10))};
     }
 
-    @Test
-    void shouldConvertEntityFromDocumentEntity() {
-
-        Person person = Person.builder().withAge()
-                .withId(12)
-                .withName("Otavio")
-                .withPhones(asList("234", "2342")).build();
-
-        var entity = converter.toCommunication(person);
-        assertEquals("Person", entity.name());
-        assertEquals(4, entity.size());
-        assertThat(entity.elements()).contains(Element.of("_id", 12L),
-                Element.of("age", 10), Element.of("name", "Otavio"),
-                Element.of("phones", Arrays.asList("234", "2342")));
-
-    }
-
-    @Test
-    void shouldConvertDocumentEntityFromEntity() {
-
-        var entity = converter.toCommunication(actor);
-        assertEquals("Actor", entity.name());
-        assertEquals(6, entity.size());
-
-        assertThat(entity.elements()).contains(documents);
-    }
-
-    @Test
-    void shouldConvertDocumentEntityToEntity() {
-        var entity = CommunicationEntity.of("Actor");
-        Stream.of(documents).forEach(entity::add);
-
-        Actor actor = converter.toEntity(Actor.class, entity);
-        assertNotNull(actor);
-        assertEquals(10, actor.getAge());
-        assertEquals(12L, actor.getId());
-        assertEquals(asList("234", "2342"), actor.getPhones());
-        assertEquals(Collections.singletonMap("JavaZone", "Jedi"), actor.getMovieCharacter());
-        assertEquals(Collections.singletonMap("JavaZone", 10), actor.getMovieRating());
-    }
-
-    @Test
-    void shouldConvertDocumentEntityToEntity2() {
-        var entity = CommunicationEntity.of("Actor");
-        Stream.of(documents).forEach(entity::add);
-
-        Actor actor = converter.toEntity(entity);
-        assertNotNull(actor);
-        assertEquals(10, actor.getAge());
-        assertEquals(12L, actor.getId());
-        assertEquals(asList("234", "2342"), actor.getPhones());
-        assertEquals(Collections.singletonMap("JavaZone", "Jedi"), actor.getMovieCharacter());
-        assertEquals(Collections.singletonMap("JavaZone", 10), actor.getMovieRating());
-    }
-
-    @Test
-    void shouldConvertDocumentEntityToExistEntity() {
-        var entity = CommunicationEntity.of("Actor");
-        Stream.of(documents).forEach(entity::add);
-        Actor actor = Actor.actorBuilder().build();
-        Actor result = converter.toEntity(actor, entity);
-
-        assertSame(actor, result);
-        assertEquals(10, actor.getAge());
-        assertEquals(12L, actor.getId());
-        assertEquals(asList("234", "2342"), actor.getPhones());
-        assertEquals(Collections.singletonMap("JavaZone", "Jedi"), actor.getMovieCharacter());
-        assertEquals(Collections.singletonMap("JavaZone", 10), actor.getMovieRating());
-    }
-
-    @Test
-    void shouldReturnErrorWhenToEntityIsNull() {
-        var entity = CommunicationEntity.of("Actor");
-        Stream.of(documents).forEach(entity::add);
-        Actor actor = Actor.actorBuilder().build();
-
-        assertThrows(NullPointerException.class, () -> converter.toEntity(null, entity));
-
-        assertThrows(NullPointerException.class, () -> converter.toEntity(actor, null));
-    }
-
-
-    @Test
-    void shouldConvertEntityToDocumentEntity2() {
-
-        Movie movie = new Movie("Matrix", 2012, Collections.singleton("Actor"));
-        Director director = Director.builderDirector().withAge(12)
-                .withId(12)
-                .withName("Otavio")
-                .withPhones(asList("234", "2342")).withMovie(movie).build();
-
-        var entity = converter.toCommunication(director);
-        assertEquals(5, entity.size());
-
-        assertEquals(getValue(entity.find("name")), director.getName());
-        assertEquals(getValue(entity.find("age")), director.getAge());
-        assertEquals(getValue(entity.find("_id")), director.getId());
-        assertEquals(getValue(entity.find("phones")), director.getPhones());
-
-
-        Element subDocument = entity.find("movie").get();
-        List<Element> documents = subDocument.get(new TypeReference<>() {
-        });
-
-        assertEquals(3, documents.size());
-        assertEquals("movie", subDocument.name());
-        assertEquals(movie.getTitle(), documents.stream().filter(c -> "title".equals(c.name())).findFirst().get().get());
-        assertEquals(movie.getYear(), documents.stream().filter(c -> "year".equals(c.name())).findFirst().get().get());
-        assertEquals(movie.getActors(), documents.stream().filter(c -> "actors".equals(c.name())).findFirst().get().get());
-
-
-    }
-
-    @Test
-    void shouldConvertToEmbeddedClassWhenHasSubDocument() {
-        Movie movie = new Movie("Matrix", 2012, Collections.singleton("Actor"));
-        Director director = Director.builderDirector().withAge(12)
-                .withId(12)
-                .withName("Otavio")
-                .withPhones(asList("234", "2342")).withMovie(movie).build();
-
-        CommunicationEntity entity = converter.toCommunication(director);
-        Director director1 = converter.toEntity(entity);
-
-        assertEquals(movie, director1.getMovie());
-        assertEquals(director.getName(), director1.getName());
-        assertEquals(director.getAge(), director1.getAge());
-        assertEquals(director.getId(), director1.getId());
-    }
-
-    @Test
-    void shouldConvertToEmbeddedClassWhenHasSubDocument2() {
-        Movie movie = new Movie("Matrix", 2012, singleton("Actor"));
-        Director director = Director.builderDirector().withAge(12)
-                .withId(12)
-                .withName("Otavio")
-                .withPhones(asList("234", "2342")).withMovie(movie).build();
-
-        var entity = converter.toCommunication(director);
-        entity.remove("movie");
-        entity.add(Element.of("movie", Arrays.asList(Element.of("title", "Matrix"),
-                Element.of("year", 2012), Element.of("actors", singleton("Actor")))));
-        Director director1 = converter.toEntity(entity);
-
-        assertEquals(movie, director1.getMovie());
-        assertEquals(director.getName(), director1.getName());
-        assertEquals(director.getAge(), director1.getAge());
-        assertEquals(director.getId(), director1.getId());
-    }
-
-    @Test
-    void shouldConvertToEmbeddedClassWhenHasSubDocument3() {
-        Movie movie = new Movie("Matrix", 2012, singleton("Actor"));
-        Director director = Director.builderDirector().withAge(12)
-                .withId(12)
-                .withName("Otavio")
-                .withPhones(asList("234", "2342")).withMovie(movie).build();
-
-        var entity = converter.toCommunication(director);
-        entity.remove("movie");
-        Map<String, Object> map = new HashMap<>();
-        map.put("title", "Matrix");
-        map.put("year", 2012);
-        map.put("actors", singleton("Actor"));
-
-        entity.add(Element.of("movie", map));
-        Director director1 = converter.toEntity(entity);
-
-        assertEquals(movie, director1.getMovie());
-        assertEquals(director.getName(), director1.getName());
-        assertEquals(director.getAge(), director1.getAge());
-        assertEquals(director.getId(), director1.getId());
-    }
-
-    @Test
-    void shouldConvertToDocumentWhenHaConverter() {
-        Worker worker = new Worker();
-        Job job = new Job();
-        job.setCity("Sao Paulo");
-        job.setDescription("Java Developer");
-        worker.setName("Bob");
-        worker.setSalary(new Money("BRL", BigDecimal.TEN));
-        worker.setJob(job);
-        var entity = converter.toCommunication(worker);
-        assertEquals("Worker", entity.name());
-        assertEquals("Bob", entity.find("name").get().get());
-        assertEquals("Sao Paulo", entity.find("city").get().get());
-        assertEquals("Java Developer", entity.find("description").get().get());
-        assertEquals("BRL 10", entity.find("money").get().get());
-    }
-
-    @Test
-    void shouldConvertToEntityWhenHasConverter() {
-        Worker worker = new Worker();
-        Job job = new Job();
-        job.setCity("Sao Paulo");
-        job.setDescription("Java Developer");
-        worker.setName("Bob");
-        worker.setSalary(new Money("BRL", BigDecimal.TEN));
-        worker.setJob(job);
-        var entity = converter.toCommunication(worker);
-        Worker worker1 = converter.toEntity(entity);
-        assertEquals(worker.getSalary(), worker1.getSalary());
-        assertEquals(job.getCity(), worker1.getJob().getCity());
-        assertEquals(job.getDescription(), worker1.getJob().getDescription());
-    }
-
-    @Test
-    void shouldConvertEmbeddableLazily() {
-        var entity = CommunicationEntity.of("Worker");
-        entity.add("name", "Otavio");
-        entity.add("money", "BRL 10");
-
-        Worker worker = converter.toEntity(entity);
-        assertEquals("Otavio", worker.getName());
-        assertEquals(new Money("BRL", BigDecimal.TEN), worker.getSalary());
-        Assertions.assertNull(worker.getJob());
-
-    }
-
-
-    @Test
-    void shouldConvertToListEmbeddable() {
-        AppointmentBook appointmentBook = new AppointmentBook("ids");
-        appointmentBook.add(Contact.builder().withType(ContactType.EMAIL)
-                .withName("Ada").withInformation("ada@lovelace.com").build());
-        appointmentBook.add(Contact.builder().withType(ContactType.MOBILE)
-                .withName("Ada").withInformation("11 1231231 123").build());
-        appointmentBook.add(Contact.builder().withType(ContactType.PHONE)
-                .withName("Ada").withInformation("12 123 1231 123123").build());
-
-        var entity = converter.toCommunication(appointmentBook);
-        var contacts = entity.find("contacts").get();
-        assertEquals("ids", appointmentBook.getId());
-        List<List<Element>> documents = (List<List<Element>>) contacts.get();
-
-        assertEquals(3L, documents.stream().flatMap(Collection::stream)
-                .filter(c -> c.name().equals("contact_name"))
-                .count());
-    }
-
-    @Test
-    void shouldConvertFromListEmbeddable() {
-        var entity = CommunicationEntity.of("AppointmentBook");
-        entity.add(Element.of("_id", "ids"));
-        List<List<Element>> documents = new ArrayList<>();
-
-        documents.add(asList(Element.of("contact_name", "Ada"), Element.of("type", ContactType.EMAIL),
-                Element.of("information", "ada@lovelace.com")));
-
-        documents.add(asList(Element.of("contact_name", "Ada"), Element.of("type", ContactType.MOBILE),
-                Element.of("information", "11 1231231 123")));
-
-        documents.add(asList(Element.of("contact_name", "Ada"), Element.of("type", ContactType.PHONE),
-                Element.of("information", "phone")));
-
-        entity.add(Element.of("contacts", documents));
-
-        AppointmentBook appointmentBook = converter.toEntity(entity);
-
-        List<Contact> contacts = appointmentBook.getContacts();
-        assertEquals("ids", appointmentBook.getId());
-        assertEquals("Ada", contacts.stream().map(Contact::getName).distinct().findFirst().get());
-
-    }
-
-
-    @Test
-    void shouldConvertSubEntity() {
-        ZipCode zipcode = new ZipCode();
-        zipcode.setZip("12321");
-        zipcode.setPlusFour("1234");
-
-        Address address = new Address();
-        address.setCity("Salvador");
-        address.setState("Bahia");
-        address.setStreet("Rua Engenheiro Jose Anasoh");
-        address.setZipCode(zipcode);
-
-        var documentEntity = converter.toCommunication(address);
-        List<Element> documents = documentEntity.elements();
-        assertEquals("Address", documentEntity.name());
-        assertEquals(4, documents.size());
-        List<Element> zip = documentEntity.find("zipCode").map(d -> d.get(new TypeReference<List<Element>>() {
-        })).orElse(Collections.emptyList());
-
-        assertEquals("Rua Engenheiro Jose Anasoh", getValue(documentEntity.find("street")));
-        assertEquals("Salvador", getValue(documentEntity.find("city")));
-        assertEquals("Bahia", getValue(documentEntity.find("state")));
-        assertEquals("12321", getValue(zip.stream().filter(d -> d.name().equals("zip")).findFirst()));
-        assertEquals("1234", getValue(zip.stream().filter(d -> d.name().equals("plusFour")).findFirst()));
-    }
-
-    @Test
-    void shouldConvertDocumentInSubEntity() {
-
-        var entity = CommunicationEntity.of("Address");
-
-        entity.add(Element.of("street", "Rua Engenheiro Jose Anasoh"));
-        entity.add(Element.of("city", "Salvador"));
-        entity.add(Element.of("state", "Bahia"));
-        entity.add(Element.of("zipCode", Arrays.asList(
-                Element.of("zip", "12321"),
-                Element.of("plusFour", "1234"))));
-        Address address = converter.toEntity(entity);
-
-        assertEquals("Rua Engenheiro Jose Anasoh", address.getStreet());
-        assertEquals("Salvador", address.getCity());
-        assertEquals("Bahia", address.getState());
-        assertEquals("12321", address.getZipCode().getZip());
-        assertEquals("1234", address.getZipCode().getPlusFour());
-
-    }
-
-    @Test
-    void shouldReturnNullWhenThereIsNotSubEntity() {
-        var entity = CommunicationEntity.of("Address");
-
-        entity.add(Element.of("street", "Rua Engenheiro Jose Anasoh"));
-        entity.add(Element.of("city", "Salvador"));
-        entity.add(Element.of("state", "Bahia"));
-        entity.add(Element.of("zip", "12321"));
-        entity.add(Element.of("plusFour", "1234"));
-
-        Address address = converter.toEntity(entity);
-
-        assertEquals("Rua Engenheiro Jose Anasoh", address.getStreet());
-        assertEquals("Salvador", address.getCity());
-        assertEquals("Bahia", address.getState());
-        assertNull(address.getZipCode());
-    }
-
-    @Test
-    void shouldConvertAndDoNotUseUnmodifiableCollection() {
-        var entity = CommunicationEntity.of("vendors");
-        entity.add("name", "name");
-        entity.add("prefixes", Arrays.asList("value", "value2"));
-
-        Vendor vendor = converter.toEntity(entity);
-        vendor.add("value3");
-
-        Assertions.assertEquals(3, vendor.getPrefixes().size());
-
-    }
-
-    @Test
-    void shouldConvertEntityToDocumentWithArray() {
-        byte[] contents = {1, 2, 3, 4, 5, 6};
-
-        var entity = CommunicationEntity.of("download");
-        entity.add("_id", 1L);
-        entity.add("contents", contents);
-
-        Download download = converter.toEntity(entity);
-        Assertions.assertEquals(1L, download.getId());
-        Assertions.assertArrayEquals(contents, download.getContents());
-    }
-
-    @Test
-    void shouldConvertDocumentToEntityWithArray() {
-        byte[] contents = {1, 2, 3, 4, 5, 6};
-
-        Download download = new Download();
-        download.setId(1L);
-        download.setContents(contents);
-
-        var entity = converter.toCommunication(download);
-
-        Assertions.assertEquals(1L, entity.find("_id").get().get());
-        final byte[] bytes = entity.find("contents").map(v -> v.get(byte[].class)).orElse(new byte[0]);
-        Assertions.assertArrayEquals(contents, bytes);
-    }
-
-    @Test
-    void shouldCreateUserScope() {
-        var entity = CommunicationEntity.of("UserScope");
-        entity.add("_id", "userName");
-        entity.add("scope", "scope");
-        entity.add("properties", Collections.singletonList(Element.of("halo", "weld")));
-
-        UserScope user = converter.toEntity(entity);
-        Assertions.assertNotNull(user);
-        Assertions.assertEquals("userName",user.getUserName());
-        Assertions.assertEquals("scope",user.getScope());
-        Assertions.assertEquals(Collections.singletonMap("halo", "weld"),user.getProperties());
-
-    }
-
-    @Test
-    void shouldCreateUserScope2() {
-        var entity = CommunicationEntity.of("UserScope");
-        entity.add("_id", "userName");
-        entity.add("scope", "scope");
-        entity.add("properties", Element.of("halo", "weld"));
-
-        UserScope user = converter.toEntity(entity);
-        Assertions.assertNotNull(user);
-        Assertions.assertEquals("userName",user.getUserName());
-        Assertions.assertEquals("scope",user.getScope());
-        Assertions.assertEquals(Collections.singletonMap("halo", "weld"),user.getProperties());
-
-    }
-
-    @Test
-    void shouldCreateLazilyEntity() {
-        var entity = CommunicationEntity.of("Citizen");
-        entity.add("id", "10");
-        entity.add("name", "Salvador");
-
-        Citizen citizen = converter.toEntity(entity);
-        Assertions.assertNotNull(citizen);
-        Assertions.assertNull(citizen.getCity());
-    }
-
-    @Test
-    void shouldConvertGroupEmbeddable(){
-        CommunicationEntity entity = CommunicationEntity.of("Wine");
-        entity.add("_id", "id");
-        entity.add("name", "Vin Blanc");
-        entity.add("factory", List.of(Element.of("name", "Napa Valley Factory"),
-                Element.of("location", "Napa Valley")));
-
-        Wine wine = converter.toEntity(entity);
-
-        SoftAssertions.assertSoftly(soft ->{
-            WineFactory factory = wine.getFactory();
-            soft.assertThat(wine).isNotNull();
-            soft.assertThat(wine.getId()).isEqualTo("id");
-            soft.assertThat(wine.getName()).isEqualTo("Vin Blanc");
-            soft.assertThat(factory).isNotNull();
-            soft.assertThat(factory.getName()).isEqualTo("Napa Valley Factory");
-            soft.assertThat(factory.getLocation()).isEqualTo("Napa Valley");
-        });
-    }
-
-    @Test
-    void shouldConvertGroupEmbeddableToCommunication(){
-
-        Wine wine = Wine.of("id", "Vin Blanc", WineFactory.of("Napa Valley Factory", "Napa Valley"));
-
-
-        var communication = converter.toCommunication(wine);
-
-        SoftAssertions.assertSoftly(soft ->{
-            soft.assertThat(communication).isNotNull();
-            soft.assertThat(communication.name()).isEqualTo("Wine");
-            soft.assertThat(communication.find("_id").orElseThrow().get()).isEqualTo("id");
-            soft.assertThat(communication.find("name").orElseThrow().get()).isEqualTo("Vin Blanc");
-            communication.find("factory").ifPresent(e -> {
-                List<Element> elements = e.get(new TypeReference<>(){});
-                soft.assertThat(elements).hasSize(2);
-                soft.assertThat(elements.stream().filter(c -> "name".equals(c.name())).findFirst().orElseThrow().get())
-                        .isEqualTo("Napa Valley Factory");
-                soft.assertThat(elements.stream().filter(c -> "location".equals(c.name())).findFirst().orElseThrow().get())
-                        .isEqualTo("Napa Valley");
+    @Nested
+    @DisplayName("When converting entities")
+    class WhenTheConversion {
+
+        @Test
+        @DisplayName("Should convert Entity From Document Entity")
+        void shouldConvertEntityFromDocumentEntity() {
+
+            Person person = Person.builder().withAge()
+                    .withId(12)
+                    .withName("Otavio")
+                    .withPhones(asList("234", "2342")).build();
+
+            var entity = converter.toCommunication(person);
+            assertThat(entity.name()).isEqualTo("Person");
+            assertThat(entity.size()).isEqualTo(4);
+            assertThat(entity.elements()).contains(Element.of("_id", 12L),
+                    Element.of("age", 10), Element.of("name", "Otavio"),
+                    Element.of("phones", Arrays.asList("234", "2342")));
+
+        }
+
+        @Test
+        @DisplayName("Should convert Document Entity From Entity")
+        void shouldConvertDocumentEntityFromEntity() {
+
+            var entity = converter.toCommunication(actor);
+            assertThat(entity.name()).isEqualTo("Actor");
+            assertThat(entity.size()).isEqualTo(6);
+
+            assertThat(entity.elements()).contains(documents);
+        }
+
+        @Test
+        @DisplayName("Should convert Document Entity To Entity")
+        void shouldConvertDocumentEntityToEntity() {
+            var entity = CommunicationEntity.of("Actor");
+            Stream.of(documents).forEach(entity::add);
+
+            Actor actor = converter.toEntity(Actor.class, entity);
+            assertThat(actor).isNotNull();
+            assertThat(actor.getAge()).isEqualTo(10);
+            assertThat(actor.getId()).isEqualTo(12L);
+            assertThat(actor.getPhones()).isEqualTo(asList("234", "2342"));
+            assertThat(actor.getMovieCharacter()).isEqualTo(Collections.singletonMap("JavaZone", "Jedi"));
+            assertThat(actor.getMovieRating()).isEqualTo(Collections.singletonMap("JavaZone", 10));
+        }
+
+        @Test
+        @DisplayName("Should convert to entity without explicit type")
+        void shouldConvertToEntityWithoutExplicitType() {
+            var entity = CommunicationEntity.of("Actor");
+            Stream.of(documents).forEach(entity::add);
+
+            Actor actor = converter.toEntity(entity);
+            assertThat(actor).isNotNull();
+            assertThat(actor.getAge()).isEqualTo(10);
+            assertThat(actor.getId()).isEqualTo(12L);
+            assertThat(actor.getPhones()).isEqualTo(asList("234", "2342"));
+            assertThat(actor.getMovieCharacter()).isEqualTo(Collections.singletonMap("JavaZone", "Jedi"));
+            assertThat(actor.getMovieRating()).isEqualTo(Collections.singletonMap("JavaZone", 10));
+        }
+
+        @Test
+        @DisplayName("Should convert Document Entity To Exist Entity")
+        void shouldConvertDocumentEntityToExistEntity() {
+            var entity = CommunicationEntity.of("Actor");
+            Stream.of(documents).forEach(entity::add);
+            Actor actor = Actor.actorBuilder().build();
+            Actor result = converter.toEntity(actor, entity);
+
+            assertThat(result).isSameAs(actor);
+            assertThat(actor.getAge()).isEqualTo(10);
+            assertThat(actor.getId()).isEqualTo(12L);
+            assertThat(actor.getPhones()).isEqualTo(asList("234", "2342"));
+            assertThat(actor.getMovieCharacter()).isEqualTo(Collections.singletonMap("JavaZone", "Jedi"));
+            assertThat(actor.getMovieRating()).isEqualTo(Collections.singletonMap("JavaZone", 10));
+        }
+
+        @Test
+        @DisplayName("Should return an error when entity conversion receives null")
+        void shouldReturnErrorWhenToEntityIsNull() {
+            var entity = CommunicationEntity.of("Actor");
+            Stream.of(documents).forEach(entity::add);
+            Actor actor = Actor.actorBuilder().build();
+
+            assertThatNullPointerException().isThrownBy(() -> converter.toEntity(null, entity));
+
+            assertThatNullPointerException().isThrownBy(() -> converter.toEntity(actor, null));
+        }
+
+
+        @Test
+        @DisplayName("Should convert an entity with an embedded movie")
+        void shouldConvertEntityWithEmbeddedMovie() {
+
+            Movie movie = new Movie("Matrix", 2012, Collections.singleton("Actor"));
+            Director director = Director.builderDirector().withAge(12)
+                    .withId(12)
+                    .withName("Otavio")
+                    .withPhones(asList("234", "2342")).withMovie(movie).build();
+
+            var entity = converter.toCommunication(director);
+            assertThat(entity.size()).isEqualTo(5);
+
+            assertThat(director.getName()).isEqualTo(getValue(entity.find("name")));
+            assertThat(director.getAge()).isEqualTo(getValue(entity.find("age")));
+            assertThat(director.getId()).isEqualTo(getValue(entity.find("_id")));
+            assertThat(director.getPhones()).isEqualTo(getValue(entity.find("phones")));
+
+
+            Element subDocument = entity.find("movie").get();
+            List<Element> documents = subDocument.get(new TypeReference<>() {
             });
 
-        });
-    }
+            assertThat(documents.size()).isEqualTo(3);
+            assertThat(subDocument.name()).isEqualTo("movie");
+            assertThat(documents.stream().filter(c -> "title".equals(c.name())).findFirst().get().get()).isEqualTo(movie.getTitle());
+            assertThat(documents.stream().filter(c -> "year".equals(c.name())).findFirst().get().get()).isEqualTo(movie.getYear());
+            assertThat(documents.stream().filter(c -> "actors".equals(c.name())).findFirst().get().get()).isEqualTo(movie.getActors());
 
+
+        }
+
+        @Test
+        @DisplayName("Should convert an embedded class from a document")
+        void shouldConvertToEmbeddedClassWhenHasSubDocument() {
+            Movie movie = new Movie("Matrix", 2012, Collections.singleton("Actor"));
+            Director director = Director.builderDirector().withAge(12)
+                    .withId(12)
+                    .withName("Otavio")
+                    .withPhones(asList("234", "2342")).withMovie(movie).build();
+
+            CommunicationEntity entity = converter.toCommunication(director);
+            Director director1 = converter.toEntity(entity);
+
+            assertThat(director1.getMovie()).isEqualTo(movie);
+            assertThat(director1.getName()).isEqualTo(director.getName());
+            assertThat(director1.getAge()).isEqualTo(director.getAge());
+            assertThat(director1.getId()).isEqualTo(director.getId());
+        }
+
+        @Test
+        @DisplayName("Should convert an embedded class from element list")
+        void shouldConvertEmbeddedClassFromElementList() {
+            Movie movie = new Movie("Matrix", 2012, singleton("Actor"));
+            Director director = Director.builderDirector().withAge(12)
+                    .withId(12)
+                    .withName("Otavio")
+                    .withPhones(asList("234", "2342")).withMovie(movie).build();
+
+            var entity = converter.toCommunication(director);
+            entity.remove("movie");
+            entity.add(Element.of("movie", Arrays.asList(Element.of("title", "Matrix"),
+                    Element.of("year", 2012), Element.of("actors", singleton("Actor")))));
+            Director director1 = converter.toEntity(entity);
+
+            assertThat(director1.getMovie()).isEqualTo(movie);
+            assertThat(director1.getName()).isEqualTo(director.getName());
+            assertThat(director1.getAge()).isEqualTo(director.getAge());
+            assertThat(director1.getId()).isEqualTo(director.getId());
+        }
+
+        @Test
+        @DisplayName("Should convert an embedded class from map")
+        void shouldConvertEmbeddedClassFromMap() {
+            Movie movie = new Movie("Matrix", 2012, singleton("Actor"));
+            Director director = Director.builderDirector().withAge(12)
+                    .withId(12)
+                    .withName("Otavio")
+                    .withPhones(asList("234", "2342")).withMovie(movie).build();
+
+            var entity = converter.toCommunication(director);
+            entity.remove("movie");
+            Map<String, Object> map = new HashMap<>();
+            map.put("title", "Matrix");
+            map.put("year", 2012);
+            map.put("actors", singleton("Actor"));
+
+            entity.add(Element.of("movie", map));
+            Director director1 = converter.toEntity(entity);
+
+            assertThat(director1.getMovie()).isEqualTo(movie);
+            assertThat(director1.getName()).isEqualTo(director.getName());
+            assertThat(director1.getAge()).isEqualTo(director.getAge());
+            assertThat(director1.getId()).isEqualTo(director.getId());
+        }
+
+        @Test
+        @DisplayName("Should convert To Document When has Converter")
+        void shouldConvertToDocumentWhenHaConverter() {
+            Worker worker = new Worker();
+            Job job = new Job();
+            job.setCity("Sao Paulo");
+            job.setDescription("Java Developer");
+            worker.setName("Bob");
+            worker.setSalary(new Money("BRL", BigDecimal.TEN));
+            worker.setJob(job);
+            var entity = converter.toCommunication(worker);
+            assertThat(entity.name()).isEqualTo("Worker");
+            assertThat(entity.find("name").get().get()).isEqualTo("Bob");
+            assertThat(entity.find("city").get().get()).isEqualTo("Sao Paulo");
+            assertThat(entity.find("description").get().get()).isEqualTo("Java Developer");
+            assertThat(entity.find("money").get().get()).isEqualTo("BRL 10");
+        }
+
+        @Test
+        @DisplayName("Should convert To Entity When Has Converter")
+        void shouldConvertToEntityWhenHasConverter() {
+            Worker worker = new Worker();
+            Job job = new Job();
+            job.setCity("Sao Paulo");
+            job.setDescription("Java Developer");
+            worker.setName("Bob");
+            worker.setSalary(new Money("BRL", BigDecimal.TEN));
+            worker.setJob(job);
+            var entity = converter.toCommunication(worker);
+            Worker worker1 = converter.toEntity(entity);
+            assertThat(worker1.getSalary()).isEqualTo(worker.getSalary());
+            assertThat(worker1.getJob().getCity()).isEqualTo(job.getCity());
+            assertThat(worker1.getJob().getDescription()).isEqualTo(job.getDescription());
+        }
+
+        @Test
+        @DisplayName("Should convert Embeddable Lazily")
+        void shouldConvertEmbeddableLazily() {
+            var entity = CommunicationEntity.of("Worker");
+            entity.add("name", "Otavio");
+            entity.add("money", "BRL 10");
+
+            Worker worker = converter.toEntity(entity);
+            assertThat(worker.getName()).isEqualTo("Otavio");
+            assertThat(worker.getSalary()).isEqualTo(new Money("BRL", BigDecimal.TEN));
+            assertThat(worker.getJob()).isNull();
+
+        }
+
+
+        @Test
+        @DisplayName("Should convert To List Embeddable")
+        void shouldConvertToListEmbeddable() {
+            AppointmentBook appointmentBook = new AppointmentBook("ids");
+            appointmentBook.add(Contact.builder().withType(ContactType.EMAIL)
+                    .withName("Ada").withInformation("ada@lovelace.com").build());
+            appointmentBook.add(Contact.builder().withType(ContactType.MOBILE)
+                    .withName("Ada").withInformation("11 1231231 123").build());
+            appointmentBook.add(Contact.builder().withType(ContactType.PHONE)
+                    .withName("Ada").withInformation("12 123 1231 123123").build());
+
+            var entity = converter.toCommunication(appointmentBook);
+            var contacts = entity.find("contacts").get();
+            assertThat(appointmentBook.getId()).isEqualTo("ids");
+            List<List<Element>> documents = (List<List<Element>>) contacts.get();
+
+            assertThat(documents.stream().flatMap(Collection::stream)
+                    .filter(c -> c.name().equals("contact_name"))
+                    .count()).isEqualTo(3L);
+        }
+
+        @Test
+        @DisplayName("Should convert From List Embeddable")
+        void shouldConvertFromListEmbeddable() {
+            var entity = CommunicationEntity.of("AppointmentBook");
+            entity.add(Element.of("_id", "ids"));
+            List<List<Element>> documents = new ArrayList<>();
+
+            documents.add(asList(Element.of("contact_name", "Ada"), Element.of("type", ContactType.EMAIL),
+                    Element.of("information", "ada@lovelace.com")));
+
+            documents.add(asList(Element.of("contact_name", "Ada"), Element.of("type", ContactType.MOBILE),
+                    Element.of("information", "11 1231231 123")));
+
+            documents.add(asList(Element.of("contact_name", "Ada"), Element.of("type", ContactType.PHONE),
+                    Element.of("information", "phone")));
+
+            entity.add(Element.of("contacts", documents));
+
+            AppointmentBook appointmentBook = converter.toEntity(entity);
+
+            List<Contact> contacts = appointmentBook.getContacts();
+            assertThat(appointmentBook.getId()).isEqualTo("ids");
+            assertThat(contacts.stream().map(Contact::getName).distinct().findFirst().get()).isEqualTo("Ada");
+
+        }
+
+
+        @Test
+        @DisplayName("Should convert Sub Entity")
+        void shouldConvertSubEntity() {
+            ZipCode zipcode = new ZipCode();
+            zipcode.setZip("12321");
+            zipcode.setPlusFour("1234");
+
+            Address address = new Address();
+            address.setCity("Salvador");
+            address.setState("Bahia");
+            address.setStreet("Rua Engenheiro Jose Anasoh");
+            address.setZipCode(zipcode);
+
+            var documentEntity = converter.toCommunication(address);
+            List<Element> documents = documentEntity.elements();
+            assertThat(documentEntity.name()).isEqualTo("Address");
+            assertThat(documents.size()).isEqualTo(4);
+            List<Element> zip = documentEntity.find("zipCode").map(d -> d.get(new TypeReference<List<Element>>() {
+            })).orElse(Collections.emptyList());
+
+            assertThat(getValue(documentEntity.find("street"))).isEqualTo("Rua Engenheiro Jose Anasoh");
+            assertThat(getValue(documentEntity.find("city"))).isEqualTo("Salvador");
+            assertThat(getValue(documentEntity.find("state"))).isEqualTo("Bahia");
+            assertThat(getValue(zip.stream().filter(d -> d.name().equals("zip")).findFirst())).isEqualTo("12321");
+            assertThat(getValue(zip.stream().filter(d -> d.name().equals("plusFour")).findFirst())).isEqualTo("1234");
+        }
+
+        @Test
+        @DisplayName("Should convert Document In Sub Entity")
+        void shouldConvertDocumentInSubEntity() {
+
+            var entity = CommunicationEntity.of("Address");
+
+            entity.add(Element.of("street", "Rua Engenheiro Jose Anasoh"));
+            entity.add(Element.of("city", "Salvador"));
+            entity.add(Element.of("state", "Bahia"));
+            entity.add(Element.of("zipCode", Arrays.asList(
+                    Element.of("zip", "12321"),
+                    Element.of("plusFour", "1234"))));
+            Address address = converter.toEntity(entity);
+
+            assertThat(address.getStreet()).isEqualTo("Rua Engenheiro Jose Anasoh");
+            assertThat(address.getCity()).isEqualTo("Salvador");
+            assertThat(address.getState()).isEqualTo("Bahia");
+            assertThat(address.getZipCode().getZip()).isEqualTo("12321");
+            assertThat(address.getZipCode().getPlusFour()).isEqualTo("1234");
+
+        }
+
+        @Test
+        @DisplayName("Should return Null When There Is Not Sub Entity")
+        void shouldReturnNullWhenThereIsNotSubEntity() {
+            var entity = CommunicationEntity.of("Address");
+
+            entity.add(Element.of("street", "Rua Engenheiro Jose Anasoh"));
+            entity.add(Element.of("city", "Salvador"));
+            entity.add(Element.of("state", "Bahia"));
+            entity.add(Element.of("zip", "12321"));
+            entity.add(Element.of("plusFour", "1234"));
+
+            Address address = converter.toEntity(entity);
+
+            assertThat(address.getStreet()).isEqualTo("Rua Engenheiro Jose Anasoh");
+            assertThat(address.getCity()).isEqualTo("Salvador");
+            assertThat(address.getState()).isEqualTo("Bahia");
+            assertThat(address.getZipCode()).isNull();
+        }
+
+        @Test
+        @DisplayName("Should convert And does not Use Unmodifiable Collection")
+        void shouldConvertAndDoNotUseUnmodifiableCollection() {
+            var entity = CommunicationEntity.of("vendors");
+            entity.add("name", "name");
+            entity.add("prefixes", Arrays.asList("value", "value2"));
+
+            Vendor vendor = converter.toEntity(entity);
+            vendor.add("value3");
+
+            assertThat(vendor.getPrefixes().size()).isEqualTo(3);
+
+        }
+
+        @Test
+        @DisplayName("Should convert Entity To Document With Array")
+        void shouldConvertEntityToDocumentWithArray() {
+            byte[] contents = {1, 2, 3, 4, 5, 6};
+
+            var entity = CommunicationEntity.of("download");
+            entity.add("_id", 1L);
+            entity.add("contents", contents);
+
+            Download download = converter.toEntity(entity);
+            assertThat(download.getId()).isEqualTo(1L);
+            assertThat(download.getContents()).containsExactly(contents);
+        }
+
+        @Test
+        @DisplayName("Should convert Document To Entity With Array")
+        void shouldConvertDocumentToEntityWithArray() {
+            byte[] contents = {1, 2, 3, 4, 5, 6};
+
+            Download download = new Download();
+            download.setId(1L);
+            download.setContents(contents);
+
+            var entity = converter.toCommunication(download);
+
+            assertThat(entity.find("_id").get().get()).isEqualTo(1L);
+            final byte[] bytes = entity.find("contents").map(v -> v.get(byte[].class)).orElse(new byte[0]);
+            assertThat(bytes).containsExactly(contents);
+        }
+
+        @Test
+        @DisplayName("Should create user scope from a collection")
+        void shouldCreateUserScope() {
+            var entity = CommunicationEntity.of("UserScope");
+            entity.add("_id", "userName");
+            entity.add("scope", "scope");
+            entity.add("properties", Collections.singletonList(Element.of("halo", "weld")));
+
+            UserScope user = converter.toEntity(entity);
+            assertThat(user).isNotNull();
+            assertThat(user.getUserName()).isEqualTo("userName");
+            assertThat(user.getScope()).isEqualTo("scope");
+            assertThat(user.getProperties()).isEqualTo(Collections.singletonMap("halo", "weld"));
+
+        }
+
+        @Test
+        @DisplayName("Should create user scope from an element")
+        void shouldCreateUserScopeFromElement() {
+            var entity = CommunicationEntity.of("UserScope");
+            entity.add("_id", "userName");
+            entity.add("scope", "scope");
+            entity.add("properties", Element.of("halo", "weld"));
+
+            UserScope user = converter.toEntity(entity);
+            assertThat(user).isNotNull();
+            assertThat(user.getUserName()).isEqualTo("userName");
+            assertThat(user.getScope()).isEqualTo("scope");
+            assertThat(user.getProperties()).isEqualTo(Collections.singletonMap("halo", "weld"));
+
+        }
+
+        @Test
+        @DisplayName("Should create Lazily Entity")
+        void shouldCreateLazilyEntity() {
+            var entity = CommunicationEntity.of("Citizen");
+            entity.add("id", "10");
+            entity.add("name", "Salvador");
+
+            Citizen citizen = converter.toEntity(entity);
+            assertThat(citizen).isNotNull();
+            assertThat(citizen.getCity()).isNull();
+        }
+
+        @Test
+        @DisplayName("Should convert Group Embeddable")
+        void shouldConvertGroupEmbeddable(){
+            CommunicationEntity entity = CommunicationEntity.of("Wine");
+            entity.add("_id", "id");
+            entity.add("name", "Vin Blanc");
+            entity.add("factory", List.of(Element.of("name", "Napa Valley Factory"),
+                    Element.of("location", "Napa Valley")));
+
+            Wine wine = converter.toEntity(entity);
+
+            assertSoftly(soft ->{
+                WineFactory factory = wine.getFactory();
+                soft.assertThat(wine).as("wine").isNotNull();
+                soft.assertThat(wine.getId()).as("wine id").isEqualTo("id");
+                soft.assertThat(wine.getName()).as("wine name").isEqualTo("Vin Blanc");
+                soft.assertThat(factory).as("wine factory").isNotNull();
+                soft.assertThat(factory.getName()).as("factory name").isEqualTo("Napa Valley Factory");
+                soft.assertThat(factory.getLocation()).as("factory location").isEqualTo("Napa Valley");
+            });
+        }
+
+        @Test
+        @DisplayName("Should convert Group Embeddable To Communication")
+        void shouldConvertGroupEmbeddableToCommunication(){
+
+            Wine wine = Wine.of("id", "Vin Blanc", WineFactory.of("Napa Valley Factory", "Napa Valley"));
+
+
+            var communication = converter.toCommunication(wine);
+
+            assertSoftly(soft ->{
+                soft.assertThat(communication).as("communication entity").isNotNull();
+                soft.assertThat(communication.name()).as("entity name").isEqualTo("Wine");
+                soft.assertThat(communication.find("_id").orElseThrow().get()).as("identifier element").isEqualTo("id");
+                soft.assertThat(communication.find("name").orElseThrow().get()).as("name element").isEqualTo("Vin Blanc");
+                communication.find("factory").ifPresent(e -> {
+                    List<Element> elements = e.get(new TypeReference<>(){});
+                    soft.assertThat(elements).as("factory elements").hasSize(2);
+                    soft.assertThat(elements.stream().filter(c -> "name".equals(c.name())).findFirst().orElseThrow().get())
+                            .as("factory name element")
+                            .isEqualTo("Napa Valley Factory");
+                    soft.assertThat(elements.stream().filter(c -> "location".equals(c.name())).findFirst().orElseThrow().get())
+                            .as("factory location element")
+                            .isEqualTo("Napa Valley");
+                });
+
+            });
+        }
+
+
+    }
 
     private Object getValue(Optional<Element> document) {
         return document.map(Element::value).map(Value::get).orElse(null);

--- a/jnosql-lite/mapping-lite-graph-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/GraphEntityConverterInheritanceTest.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/GraphEntityConverterInheritanceTest.java
@@ -36,7 +36,8 @@ import org.eclipse.jnosql.mapping.semistructured.EntityConverter;
 import org.jboss.weld.junit5.auto.AddExtensions;
 import org.jboss.weld.junit5.auto.AddPackages;
 import org.jboss.weld.junit5.auto.EnableAutoWeld;
-import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
@@ -46,8 +47,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 @EnableAutoWeld
 @AddPackages(value = {Converters.class, EntityConverter.class, GraphTemplate.class})
@@ -58,375 +58,400 @@ class GraphEntityConverterInheritanceTest {
     @Inject
     private EntityConverter converter;
 
-    @Test
-    void shouldConvertProjectToSmallProject() {
-        var entity = CommunicationEntity.of("Project");
-        entity.add("_id", "Small Project");
-        entity.add("investor", "Otavio Santana");
-        entity.add("size", "Small");
-        Project project = this.converter.toEntity(entity);
-        assertEquals("Small Project", project.getName());
-        assertEquals(SmallProject.class, project.getClass());
-        SmallProject smallProject = (SmallProject) project;
-        assertEquals("Otavio Santana", smallProject.getInvestor());
-    }
+    @Nested
+    @DisplayName("When converting inherited entities")
+    class WhenTheConversion {
 
-    @Test
-    void shouldConvertProjectToLargeProject() {
-        var entity = CommunicationEntity.of("Project");
-        entity.add("_id", "Large Project");
-        entity.add("budget", BigDecimal.TEN);
-        entity.add("size", "Large");
-        Project project = this.converter.toEntity(entity);
-        assertEquals("Large Project", project.getName());
-        assertEquals(LargeProject.class, project.getClass());
-        LargeProject smallProject = (LargeProject) project;
-        assertEquals(BigDecimal.TEN, smallProject.getBudget());
-    }
+        @Test
+        @DisplayName("Should convert project to small project")
+        void shouldConvertProjectToSmallProject() {
+            var entity = CommunicationEntity.of("Project");
+            entity.add("_id", "Small Project");
+            entity.add("investor", "Otavio Santana");
+            entity.add("size", "Small");
+            Project project = converter.toEntity(entity);
+            assertThat(project.getName()).isEqualTo("Small Project");
+            assertThat(project.getClass()).isEqualTo(SmallProject.class);
+            SmallProject smallProject = (SmallProject) project;
+            assertThat(smallProject.getInvestor()).isEqualTo("Otavio Santana");
+        }
 
-    @Test
-    void shouldConvertLargeProjectToCommunicationEntity() {
-        LargeProject project = new LargeProject();
-        project.setName("Large Project");
-        project.setBudget(BigDecimal.TEN);
-        var entity = this.converter.toCommunication(project);
-        assertNotNull(entity);
-        assertEquals("Project", entity.name());
-        assertEquals(project.getName(), entity.find("_id", String.class).get());
-        assertEquals(project.getBudget(), entity.find("budget", BigDecimal.class).get());
-        assertEquals("Large", entity.find("size", String.class).get());
-    }
+        @Test
+        @DisplayName("Should convert project to large project")
+        void shouldConvertProjectToLargeProject() {
+            var entity = CommunicationEntity.of("Project");
+            entity.add("_id", "Large Project");
+            entity.add("budget", BigDecimal.TEN);
+            entity.add("size", "Large");
+            Project project = converter.toEntity(entity);
+            assertThat(project.getName()).isEqualTo("Large Project");
+            assertThat(project.getClass()).isEqualTo(LargeProject.class);
+            LargeProject smallProject = (LargeProject) project;
+            assertThat(smallProject.getBudget()).isEqualTo(BigDecimal.TEN);
+        }
 
-    @Test
-    void shouldConvertSmallProjectToCommunicationEntity() {
-        SmallProject project = new SmallProject();
-        project.setName("Small Project");
-        project.setInvestor("Otavio Santana");
-        var entity = this.converter.toCommunication(project);
-        assertNotNull(entity);
-        assertEquals("Project", entity.name());
-        assertEquals(project.getName(), entity.find("_id", String.class).get());
-        assertEquals(project.getInvestor(), entity.find("investor", String.class).get());
-        assertEquals("Small", entity.find("size", String.class).get());
-    }
+        @Test
+        @DisplayName("Should convert large project to communication entity")
+        void shouldConvertLargeProjectToCommunicationEntity() {
+            LargeProject project = new LargeProject();
+            project.setName("Large Project");
+            project.setBudget(BigDecimal.TEN);
+            var entity = converter.toCommunication(project);
+            assertThat(entity).isNotNull();
+            assertThat(entity.name()).isEqualTo("Project");
+            assertThat(entity.find("_id", String.class).get()).isEqualTo(project.getName());
+            assertThat(entity.find("budget", BigDecimal.class).get()).isEqualTo(project.getBudget());
+            assertThat(entity.find("size", String.class).get()).isEqualTo("Large");
+        }
 
-    @Test
-    void shouldConvertProject() {
-        var entity = CommunicationEntity.of("Project");
-        entity.add("_id", "Project");
-        entity.add("size", "Project");
-        Project project = this.converter.toEntity(entity);
-        assertEquals("Project", project.getName());
-    }
+        @Test
+        @DisplayName("Should convert small project to communication entity")
+        void shouldConvertSmallProjectToCommunicationEntity() {
+            SmallProject project = new SmallProject();
+            project.setName("Small Project");
+            project.setInvestor("Otavio Santana");
+            var entity = converter.toCommunication(project);
+            assertThat(entity).isNotNull();
+            assertThat(entity.name()).isEqualTo("Project");
+            assertThat(entity.find("_id", String.class).get()).isEqualTo(project.getName());
+            assertThat(entity.find("investor", String.class).get()).isEqualTo(project.getInvestor());
+            assertThat(entity.find("size", String.class).get()).isEqualTo("Small");
+        }
 
-    @Test
-    void shouldConvertProjectToCommunicationEntity() {
-        Project project = new Project();
-        project.setName("Large Project");
-        var entity = this.converter.toCommunication(project);
-        assertNotNull(entity);
-        assertEquals("Project", entity.name());
-        assertEquals(project.getName(), entity.find("_id", String.class).get());
-        assertEquals("Project", entity.find("size", String.class).get());
-    }
+        @Test
+        @DisplayName("Should convert project")
+        void shouldConvertProject() {
+            var entity = CommunicationEntity.of("Project");
+            entity.add("_id", "Project");
+            entity.add("size", "Project");
+            Project project = converter.toEntity(entity);
+            assertThat(project.getName()).isEqualTo("Project");
+        }
 
-    @Test
-    void shouldConvertDocumentEntityToSocialMedia(){
-        LocalDate date = LocalDate.now();
-        var entity = CommunicationEntity.of("Notification");
-        entity.add("_id", 100L);
-        entity.add("name", "Social Media");
-        entity.add("nickname", "otaviojava");
-        entity.add("createdOn",date);
-        entity.add("dtype", SocialMediaNotification.class.getSimpleName());
-        SocialMediaNotification notification = this.converter.toEntity(entity);
-        assertEquals(100L, notification.getId());
-        assertEquals("Social Media", notification.getName());
-        assertEquals("otaviojava", notification.getNickname());
-        assertEquals(date, notification.getCreatedOn());
-    }
+        @Test
+        @DisplayName("Should convert project to communication entity")
+        void shouldConvertProjectToCommunicationEntity() {
+            Project project = new Project();
+            project.setName("Large Project");
+            var entity = converter.toCommunication(project);
+            assertThat(entity).isNotNull();
+            assertThat(entity.name()).isEqualTo("Project");
+            assertThat(entity.find("_id", String.class).get()).isEqualTo(project.getName());
+            assertThat(entity.find("size", String.class).get()).isEqualTo("Project");
+        }
 
-    @Test
-    void shouldConvertDocumentEntityToSms(){
-        LocalDate date = LocalDate.now();
-        var entity = CommunicationEntity.of("Notification");
-        entity.add("_id", 100L);
-        entity.add("name", "SMS Notification");
-        entity.add("phone", "+351987654123");
-        entity.add("createdOn", date);
-        entity.add("dtype", "SMS");
-        SmsNotification notification = this.converter.toEntity(entity);
-        Assertions.assertEquals(100L, notification.getId());
-        Assertions.assertEquals("SMS Notification", notification.getName());
-        Assertions.assertEquals("+351987654123", notification.getPhone());
-        assertEquals(date, notification.getCreatedOn());
-    }
+        @Test
+        @DisplayName("Should convert document entity to social media notification")
+        void shouldConvertDocumentEntityToSocialMedia(){
+            LocalDate date = LocalDate.now();
+            var entity = CommunicationEntity.of("Notification");
+            entity.add("_id", 100L);
+            entity.add("name", "Social Media");
+            entity.add("nickname", "otaviojava");
+            entity.add("createdOn",date);
+            entity.add("dtype", SocialMediaNotification.class.getSimpleName());
+            SocialMediaNotification notification = converter.toEntity(entity);
+            assertThat(notification.getId()).isEqualTo(100L);
+            assertThat(notification.getName()).isEqualTo("Social Media");
+            assertThat(notification.getNickname()).isEqualTo("otaviojava");
+            assertThat(notification.getCreatedOn()).isEqualTo(date);
+        }
 
-    @Test
-    void shouldConvertDocumentEntityToEmail(){
-        LocalDate date = LocalDate.now();
-        var entity = CommunicationEntity.of("Notification");
-        entity.add("_id", 100L);
-        entity.add("name", "Email Notification");
-        entity.add("email", "otavio@otavio.test");
-        entity.add("createdOn", date);
-        entity.add("dtype", "Email");
-        EmailNotification notification = this.converter.toEntity(entity);
-        Assertions.assertEquals(100L, notification.getId());
-        Assertions.assertEquals("Email Notification", notification.getName());
-        Assertions.assertEquals("otavio@otavio.test", notification.getEmail());
-        assertEquals(date, notification.getCreatedOn());
-    }
+        @Test
+        @DisplayName("Should convert document entity to SMS notification")
+        void shouldConvertDocumentEntityToSms(){
+            LocalDate date = LocalDate.now();
+            var entity = CommunicationEntity.of("Notification");
+            entity.add("_id", 100L);
+            entity.add("name", "SMS Notification");
+            entity.add("phone", "+351987654123");
+            entity.add("createdOn", date);
+            entity.add("dtype", "SMS");
+            SmsNotification notification = converter.toEntity(entity);
+            assertThat(notification.getId()).isEqualTo(100L);
+            assertThat(notification.getName()).isEqualTo("SMS Notification");
+            assertThat(notification.getPhone()).isEqualTo("+351987654123");
+            assertThat(notification.getCreatedOn()).isEqualTo(date);
+        }
 
-    @Test
-    void shouldConvertSocialMediaToCommunicationEntity(){
-        SocialMediaNotification notification = new SocialMediaNotification();
-        notification.setId(100L);
-        notification.setName("Social Media");
-        notification.setCreatedOn(LocalDate.now());
-        notification.setNickname("otaviojava");
-        var entity = this.converter.toCommunication(notification);
-        assertNotNull(entity);
-        assertEquals("Notification", entity.name());
-        assertEquals(notification.getId(), entity.find("_id", Long.class).get());
-        assertEquals(notification.getName(), entity.find("name", String.class).get());
-        assertEquals(notification.getNickname(), entity.find("nickname", String.class).get());
-        assertEquals(notification.getCreatedOn(), entity.find("createdOn", LocalDate.class).get());
-    }
+        @Test
+        @DisplayName("Should convert document entity to email notification")
+        void shouldConvertDocumentEntityToEmail(){
+            LocalDate date = LocalDate.now();
+            var entity = CommunicationEntity.of("Notification");
+            entity.add("_id", 100L);
+            entity.add("name", "Email Notification");
+            entity.add("email", "otavio@otavio.test");
+            entity.add("createdOn", date);
+            entity.add("dtype", "Email");
+            EmailNotification notification = converter.toEntity(entity);
+            assertThat(notification.getId()).isEqualTo(100L);
+            assertThat(notification.getName()).isEqualTo("Email Notification");
+            assertThat(notification.getEmail()).isEqualTo("otavio@otavio.test");
+            assertThat(notification.getCreatedOn()).isEqualTo(date);
+        }
 
-    @Test
-    void shouldConvertSmsToCommunicationEntity(){
-        SmsNotification notification = new SmsNotification();
-        notification.setId(100L);
-        notification.setName("SMS");
-        notification.setCreatedOn(LocalDate.now());
-        notification.setPhone("+351123456987");
-        var entity = this.converter.toCommunication(notification);
-        assertNotNull(entity);
-        assertEquals("Notification", entity.name());
-        assertEquals(notification.getId(), entity.find("_id", Long.class).get());
-        assertEquals(notification.getName(), entity.find("name", String.class).get());
-        assertEquals(notification.getPhone(), entity.find("phone", String.class).get());
-        assertEquals(notification.getCreatedOn(), entity.find("createdOn", LocalDate.class).get());
-    }
+        @Test
+        @DisplayName("Should convert social media notification to communication entity")
+        void shouldConvertSocialMediaToCommunicationEntity(){
+            SocialMediaNotification notification = new SocialMediaNotification();
+            notification.setId(100L);
+            notification.setName("Social Media");
+            notification.setCreatedOn(LocalDate.now());
+            notification.setNickname("otaviojava");
+            var entity = converter.toCommunication(notification);
+            assertThat(entity).isNotNull();
+            assertThat(entity.name()).isEqualTo("Notification");
+            assertThat(entity.find("_id", Long.class).get()).isEqualTo(notification.getId());
+            assertThat(entity.find("name", String.class).get()).isEqualTo(notification.getName());
+            assertThat(entity.find("nickname", String.class).get()).isEqualTo(notification.getNickname());
+            assertThat(entity.find("createdOn", LocalDate.class).get()).isEqualTo(notification.getCreatedOn());
+        }
 
-    @Test
-    void shouldConvertEmailToCommunicationEntity(){
-        EmailNotification notification = new EmailNotification();
-        notification.setId(100L);
-        notification.setName("Email Media");
-        notification.setCreatedOn(LocalDate.now());
-        notification.setEmail("otavio@otavio.test.com");
-        var entity = this.converter.toCommunication(notification);
-        assertNotNull(entity);
-        assertEquals("Notification", entity.name());
-        assertEquals(notification.getId(), entity.find("_id", Long.class).get());
-        assertEquals(notification.getName(), entity.find("name", String.class).get());
-        assertEquals(notification.getEmail(), entity.find("email", String.class).get());
-        assertEquals(notification.getCreatedOn(), entity.find("createdOn", LocalDate.class).get());
-    }
+        @Test
+        @DisplayName("Should convert SMS notification to communication entity")
+        void shouldConvertSmsToCommunicationEntity(){
+            SmsNotification notification = new SmsNotification();
+            notification.setId(100L);
+            notification.setName("SMS");
+            notification.setCreatedOn(LocalDate.now());
+            notification.setPhone("+351123456987");
+            var entity = converter.toCommunication(notification);
+            assertThat(entity).isNotNull();
+            assertThat(entity.name()).isEqualTo("Notification");
+            assertThat(entity.find("_id", Long.class).get()).isEqualTo(notification.getId());
+            assertThat(entity.find("name", String.class).get()).isEqualTo(notification.getName());
+            assertThat(entity.find("phone", String.class).get()).isEqualTo(notification.getPhone());
+            assertThat(entity.find("createdOn", LocalDate.class).get()).isEqualTo(notification.getCreatedOn());
+        }
 
-    @Test
-    void shouldReturnErrorWhenConvertMissingDocument(){
-        LocalDate date = LocalDate.now();
-        var entity = CommunicationEntity.of("Notification");
-        entity.add("_id", 100L);
-        entity.add("name", "SMS Notification");
-        entity.add("phone", "+351987654123");
-        entity.add("createdOn", date);
-        Assertions.assertThrows(MappingException.class, ()-> this.converter.toEntity(entity));
-    }
+        @Test
+        @DisplayName("Should convert email notification to communication entity")
+        void shouldConvertEmailToCommunicationEntity(){
+            EmailNotification notification = new EmailNotification();
+            notification.setId(100L);
+            notification.setName("Email Media");
+            notification.setCreatedOn(LocalDate.now());
+            notification.setEmail("otavio@otavio.test.com");
+            var entity = converter.toCommunication(notification);
+            assertThat(entity).isNotNull();
+            assertThat(entity.name()).isEqualTo("Notification");
+            assertThat(entity.find("_id", Long.class).get()).isEqualTo(notification.getId());
+            assertThat(entity.find("name", String.class).get()).isEqualTo(notification.getName());
+            assertThat(entity.find("email", String.class).get()).isEqualTo(notification.getEmail());
+            assertThat(entity.find("createdOn", LocalDate.class).get()).isEqualTo(notification.getCreatedOn());
+        }
 
-    @Test
-    void shouldReturnErrorWhenMismatchField() {
-        LocalDate date = LocalDate.now();
-        var entity = CommunicationEntity.of("Notification");
-        entity.add("_id", 100L);
-        entity.add("name", "Email Notification");
-        entity.add("email", "otavio@otavio.test");
-        entity.add("createdOn", date);
-        entity.add("dtype", "Wrong");
-        Assertions.assertThrows(MappingException.class, ()-> this.converter.toEntity(entity));
-    }
+        @Test
+        @DisplayName("Should return an error when document discriminator is missing")
+        void shouldReturnErrorWhenConvertMissingDocument(){
+            LocalDate date = LocalDate.now();
+            var entity = CommunicationEntity.of("Notification");
+            entity.add("_id", 100L);
+            entity.add("name", "SMS Notification");
+            entity.add("phone", "+351987654123");
+            entity.add("createdOn", date);
+            assertThatExceptionOfType(MappingException.class).isThrownBy(() -> converter.toEntity(entity));
+        }
+
+        @Test
+        @DisplayName("Should return an error when discriminator does not match")
+        void shouldReturnErrorWhenMismatchField() {
+            LocalDate date = LocalDate.now();
+            var entity = CommunicationEntity.of("Notification");
+            entity.add("_id", 100L);
+            entity.add("name", "Email Notification");
+            entity.add("email", "otavio@otavio.test");
+            entity.add("createdOn", date);
+            entity.add("dtype", "Wrong");
+            assertThatExceptionOfType(MappingException.class).isThrownBy(() -> converter.toEntity(entity));
+        }
 
 
 
-    @Test
-    void shouldConvertCommunicationNotificationReaderEmail() {
-        var entity = CommunicationEntity.of("NotificationReader");
-        entity.add("_id", "poli");
-        entity.add("name", "Poliana Santana");
-        entity.add("notification", Arrays.asList(
-                Element.of("_id", 10L),
-                Element.of("name", "News"),
-                Element.of("email", "otavio@email.com"),
-                Element.of("_id", LocalDate.now()),
-                Element.of("dtype", "Email")
-        ));
+        @Test
+        @DisplayName("Should convert notification reader with email notification")
+        void shouldConvertCommunicationNotificationReaderEmail() {
+            var entity = CommunicationEntity.of("NotificationReader");
+            entity.add("_id", "poli");
+            entity.add("name", "Poliana Santana");
+            entity.add("notification", Arrays.asList(
+                    Element.of("_id", 10L),
+                    Element.of("name", "News"),
+                    Element.of("email", "otavio@email.com"),
+                    Element.of("_id", LocalDate.now()),
+                    Element.of("dtype", "Email")
+            ));
 
-        NotificationReader notificationReader = converter.toEntity(entity);
-        assertNotNull(notificationReader);
-        Assertions.assertEquals("poli", notificationReader.getNickname());
-        Assertions.assertEquals("Poliana Santana", notificationReader.getName());
-        Notification notification = notificationReader.getNotification();
-        assertNotNull(notification);
-        Assertions.assertEquals(EmailNotification.class, notification.getClass());
-        EmailNotification email = (EmailNotification) notification;
-        Assertions.assertEquals(10L, email.getId());
-        Assertions.assertEquals("News", email.getName());
-        Assertions.assertEquals("otavio@email.com", email.getEmail());
-    }
+            NotificationReader notificationReader = converter.toEntity(entity);
+            assertThat(notificationReader).isNotNull();
+            assertThat(notificationReader.getNickname()).isEqualTo("poli");
+            assertThat(notificationReader.getName()).isEqualTo("Poliana Santana");
+            Notification notification = notificationReader.getNotification();
+            assertThat(notification).isNotNull();
+            assertThat(notification.getClass()).isEqualTo(EmailNotification.class);
+            EmailNotification email = (EmailNotification) notification;
+            assertThat(email.getId()).isEqualTo(10L);
+            assertThat(email.getName()).isEqualTo("News");
+            assertThat(email.getEmail()).isEqualTo("otavio@email.com");
+        }
 
-    @Test
-    void shouldConvertCommunicationNotificationReaderSms() {
-        var entity = CommunicationEntity.of("NotificationReader");
-        entity.add("_id", "poli");
-        entity.add("name", "Poliana Santana");
-        entity.add("notification", Arrays.asList(
-                Element.of("_id", 10L),
-                Element.of("name", "News"),
-                Element.of("phone", "123456789"),
-                Element.of("_id", LocalDate.now()),
-                Element.of("dtype", "SMS")
-        ));
+        @Test
+        @DisplayName("Should convert notification reader with SMS notification")
+        void shouldConvertCommunicationNotificationReaderSms() {
+            var entity = CommunicationEntity.of("NotificationReader");
+            entity.add("_id", "poli");
+            entity.add("name", "Poliana Santana");
+            entity.add("notification", Arrays.asList(
+                    Element.of("_id", 10L),
+                    Element.of("name", "News"),
+                    Element.of("phone", "123456789"),
+                    Element.of("_id", LocalDate.now()),
+                    Element.of("dtype", "SMS")
+            ));
 
-        NotificationReader notificationReader = converter.toEntity(entity);
-        assertNotNull(notificationReader);
-        Assertions.assertEquals("poli", notificationReader.getNickname());
-        Assertions.assertEquals("Poliana Santana", notificationReader.getName());
-        Notification notification = notificationReader.getNotification();
-        assertNotNull(notification);
-        Assertions.assertEquals(SmsNotification.class, notification.getClass());
-        SmsNotification sms = (SmsNotification) notification;
-        Assertions.assertEquals(10L, sms.getId());
-        Assertions.assertEquals("News", sms.getName());
-        Assertions.assertEquals("123456789", sms.getPhone());
-    }
+            NotificationReader notificationReader = converter.toEntity(entity);
+            assertThat(notificationReader).isNotNull();
+            assertThat(notificationReader.getNickname()).isEqualTo("poli");
+            assertThat(notificationReader.getName()).isEqualTo("Poliana Santana");
+            Notification notification = notificationReader.getNotification();
+            assertThat(notification).isNotNull();
+            assertThat(notification.getClass()).isEqualTo(SmsNotification.class);
+            SmsNotification sms = (SmsNotification) notification;
+            assertThat(sms.getId()).isEqualTo(10L);
+            assertThat(sms.getName()).isEqualTo("News");
+            assertThat(sms.getPhone()).isEqualTo("123456789");
+        }
 
-    @Test
-    void shouldConvertCommunicationNotificationReaderSocial() {
-        var entity = CommunicationEntity.of("NotificationReader");
-        entity.add("_id", "poli");
-        entity.add("name", "Poliana Santana");
-        entity.add("notification", Arrays.asList(
-                Element.of("_id", 10L),
-                Element.of("name", "News"),
-                Element.of("nickname", "123456789"),
-                Element.of("_id", LocalDate.now()),
-                Element.of("dtype", "SocialMediaNotification")
-        ));
+        @Test
+        @DisplayName("Should convert notification reader with social notification")
+        void shouldConvertCommunicationNotificationReaderSocial() {
+            var entity = CommunicationEntity.of("NotificationReader");
+            entity.add("_id", "poli");
+            entity.add("name", "Poliana Santana");
+            entity.add("notification", Arrays.asList(
+                    Element.of("_id", 10L),
+                    Element.of("name", "News"),
+                    Element.of("nickname", "123456789"),
+                    Element.of("_id", LocalDate.now()),
+                    Element.of("dtype", "SocialMediaNotification")
+            ));
 
-        NotificationReader notificationReader = converter.toEntity(entity);
-        assertNotNull(notificationReader);
-        Assertions.assertEquals("poli", notificationReader.getNickname());
-        Assertions.assertEquals("Poliana Santana", notificationReader.getName());
-        Notification notification = notificationReader.getNotification();
-        assertNotNull(notification);
-        Assertions.assertEquals(SocialMediaNotification.class, notification.getClass());
-        SocialMediaNotification social = (SocialMediaNotification) notification;
-        Assertions.assertEquals(10L, social.getId());
-        Assertions.assertEquals("News", social.getName());
-        Assertions.assertEquals("123456789", social.getNickname());
-    }
+            NotificationReader notificationReader = converter.toEntity(entity);
+            assertThat(notificationReader).isNotNull();
+            assertThat(notificationReader.getNickname()).isEqualTo("poli");
+            assertThat(notificationReader.getName()).isEqualTo("Poliana Santana");
+            Notification notification = notificationReader.getNotification();
+            assertThat(notification).isNotNull();
+            assertThat(notification.getClass()).isEqualTo(SocialMediaNotification.class);
+            SocialMediaNotification social = (SocialMediaNotification) notification;
+            assertThat(social.getId()).isEqualTo(10L);
+            assertThat(social.getName()).isEqualTo("News");
+            assertThat(social.getNickname()).isEqualTo("123456789");
+        }
 
-    @Test
-    void shouldConvertSocialCommunication() {
-        SocialMediaNotification notification = new SocialMediaNotification();
-        notification.setId(10L);
-        notification.setName("Ada");
-        notification.setNickname("ada.lovelace");
-        NotificationReader reader = new NotificationReader("otavio", "Otavio", notification);
+        @Test
+        @DisplayName("Should convert social notification reader to communication entity")
+        void shouldConvertSocialNotificationReaderToCommunication() {
+            SocialMediaNotification notification = new SocialMediaNotification();
+            notification.setId(10L);
+            notification.setName("Ada");
+            notification.setNickname("ada.lovelace");
+            NotificationReader reader = new NotificationReader("otavio", "Otavio", notification);
 
-        var entity = this.converter.toCommunication(reader);
-        assertNotNull(entity);
+            var entity = converter.toCommunication(reader);
+            assertThat(entity).isNotNull();
 
-        assertEquals("NotificationReader", entity.name());
-        assertEquals("otavio", entity.find("_id", String.class).get());
-        assertEquals("Otavio", entity.find("name", String.class).get());
-        List<Element> documents = entity.find("notification", new TypeReference<List<Element>>() {
-        }).get();
+            assertThat(entity.name()).isEqualTo("NotificationReader");
+            assertThat(entity.find("_id", String.class).get()).isEqualTo("otavio");
+            assertThat(entity.find("name", String.class).get()).isEqualTo("Otavio");
+            List<Element> documents = entity.find("notification", new TypeReference<List<Element>>() {
+            }).get();
 
-        assertThat(documents).contains(Element.of("_id", 10L),
-                Element.of("name", "Ada"),
-                Element.of("dtype", "SocialMediaNotification"),
-                Element.of("nickname", "ada.lovelace"));
-    }
+            assertThat(documents).contains(Element.of("_id", 10L),
+                    Element.of("name", "Ada"),
+                    Element.of("dtype", "SocialMediaNotification"),
+                    Element.of("nickname", "ada.lovelace"));
+        }
 
-    @Test
-    void shouldConvertConvertProjectManagerCommunication() {
-        LargeProject large = new LargeProject();
-        large.setBudget(BigDecimal.TEN);
-        large.setName("large");
+        @Test
+        @DisplayName("Should convert project manager to communication entity")
+        void shouldConvertProjectManagerToCommunication() {
+            LargeProject large = new LargeProject();
+            large.setBudget(BigDecimal.TEN);
+            large.setName("large");
 
-        SmallProject small = new SmallProject();
-        small.setInvestor("new investor");
-        small.setName("Start up");
+            SmallProject small = new SmallProject();
+            small.setInvestor("new investor");
+            small.setName("Start up");
 
-        List<Project> projects = new ArrayList<>();
-        projects.add(large);
-        projects.add(small);
+            List<Project> projects = new ArrayList<>();
+            projects.add(large);
+            projects.add(small);
 
-        ProjectManager manager = ProjectManager.of(10L, "manager", projects);
-        var entity = this.converter.toCommunication(manager);
-        assertNotNull(entity);
+            ProjectManager manager = ProjectManager.of(10L, "manager", projects);
+            var entity = converter.toCommunication(manager);
+            assertThat(entity).isNotNull();
 
-        assertEquals("ProjectManager", entity.name());
-        assertEquals(10L, entity.find("_id", Long.class).get());
-        assertEquals("manager", entity.find("name", String.class).get());
+            assertThat(entity.name()).isEqualTo("ProjectManager");
+            assertThat(entity.find("_id", Long.class).get()).isEqualTo(10L);
+            assertThat(entity.find("name", String.class).get()).isEqualTo("manager");
 
-        List<List<Element>> documents = (List<List<Element>>) entity.find("projects").get().get();
+            List<List<Element>> documents = (List<List<Element>>) entity.find("projects").get().get();
 
-        List<Element> largeCommunication = documents.get(0);
-        List<Element> smallCommunication = documents.get(1);
-        assertThat(largeCommunication).contains(
-                Element.of("_id", "large"),
-                Element.of("size", "Large"),
-                Element.of("budget", BigDecimal.TEN)
-        );
+            List<Element> largeCommunication = documents.get(0);
+            List<Element> smallCommunication = documents.get(1);
+            assertThat(largeCommunication).contains(
+                    Element.of("_id", "large"),
+                    Element.of("size", "Large"),
+                    Element.of("budget", BigDecimal.TEN)
+            );
 
-        assertThat(smallCommunication).contains(
-                Element.of("size", "Small"),
-                Element.of("investor", "new investor"),
-                Element.of("_id", "Start up")
-        );
+            assertThat(smallCommunication).contains(
+                    Element.of("size", "Small"),
+                    Element.of("investor", "new investor"),
+                    Element.of("_id", "Start up")
+            );
 
-    }
+        }
 
-    @Test
-    void shouldConvertConvertCommunicationProjectManager() {
-        var communication = CommunicationEntity.of("ProjectManager");
-        communication.add("_id", 10L);
-        communication.add("name", "manager");
-        List<List<Element>> documents = new ArrayList<>();
-        documents.add(Arrays.asList(
-                Element.of("_id","small-project"),
-                Element.of("size","Small"),
-                Element.of("investor","investor")
-        ));
-        documents.add(Arrays.asList(
-                Element.of("_id","large-project"),
-                Element.of("size","Large"),
-                Element.of("budget",BigDecimal.TEN)
-        ));
-        communication.add("projects", documents);
+        @Test
+        @DisplayName("Should convert communication entity to project manager")
+        void shouldConvertCommunicationToProjectManager() {
+            var communication = CommunicationEntity.of("ProjectManager");
+            communication.add("_id", 10L);
+            communication.add("name", "manager");
+            List<List<Element>> documents = new ArrayList<>();
+            documents.add(Arrays.asList(
+                    Element.of("_id","small-project"),
+                    Element.of("size","Small"),
+                    Element.of("investor","investor")
+            ));
+            documents.add(Arrays.asList(
+                    Element.of("_id","large-project"),
+                    Element.of("size","Large"),
+                    Element.of("budget",BigDecimal.TEN)
+            ));
+            communication.add("projects", documents);
 
-        ProjectManager manager = converter.toEntity(communication);
-        assertNotNull(manager);
+            ProjectManager manager = converter.toEntity(communication);
+            assertThat(manager).isNotNull();
 
-        assertEquals(10L, manager.getId());
-        assertEquals("manager", manager.getName());
+            assertThat(manager.getId()).isEqualTo(10L);
+            assertThat(manager.getName()).isEqualTo("manager");
 
-        List<Project> projects = manager.getProjects();
-        assertEquals(2, projects.size());
-        SmallProject small = (SmallProject) projects.get(0);
-        LargeProject large = (LargeProject) projects.get(1);
-        assertNotNull(small);
-        assertEquals("small-project", small.getName());
-        assertEquals("investor", small.getInvestor());
+            List<Project> projects = manager.getProjects();
+            assertThat(projects.size()).isEqualTo(2);
+            SmallProject small = (SmallProject) projects.get(0);
+            LargeProject large = (LargeProject) projects.get(1);
+            assertThat(small).isNotNull();
+            assertThat(small.getName()).isEqualTo("small-project");
+            assertThat(small.getInvestor()).isEqualTo("investor");
 
-        assertNotNull(large);
-        assertEquals("large-project", large.getName());
-        assertEquals(BigDecimal.TEN, large.getBudget());
+            assertThat(large).isNotNull();
+            assertThat(large.getName()).isEqualTo("large-project");
+            assertThat(large.getBudget()).isEqualTo(BigDecimal.TEN);
 
+        }
     }
 }

--- a/jnosql-lite/mapping-lite-graph-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/GraphEntityConverterTest.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/GraphEntityConverterTest.java
@@ -15,7 +15,6 @@
 package org.eclipse.jnosql.lite.mapping.entities;
 
 import jakarta.inject.Inject;
-import org.assertj.core.api.SoftAssertions;
 import org.eclipse.jnosql.communication.TypeReference;
 import org.eclipse.jnosql.communication.Value;
 import org.eclipse.jnosql.communication.semistructured.CommunicationEntity;
@@ -27,8 +26,9 @@ import org.eclipse.jnosql.mapping.semistructured.EntityConverter;
 import org.jboss.weld.junit5.auto.AddExtensions;
 import org.jboss.weld.junit5.auto.AddPackages;
 import org.jboss.weld.junit5.auto.EnableAutoWeld;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
@@ -44,12 +44,9 @@ import java.util.stream.Stream;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singleton;
-import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 @EnableAutoWeld
 @AddPackages(value = {Converters.class, EntityConverter.class})
@@ -80,466 +77,500 @@ public class GraphEntityConverterTest {
                 , Element.of("movieRating", Collections.singletonMap("JavaZone", 10))};
     }
 
-    @Test
-    void shouldConvertEntityFromDocumentEntity() {
-
-        Person person = Person.builder().withAge()
-                .withId(12)
-                .withName("Otavio")
-                .withPhones(asList("234", "2342")).build();
-
-        var entity = converter.toCommunication(person);
-        assertEquals("Person", entity.name());
-        assertEquals(4, entity.size());
-        assertThat(entity.elements()).contains(Element.of("_id", 12L),
-                Element.of("age", 10), Element.of("name", "Otavio"),
-                Element.of("phones", Arrays.asList("234", "2342")));
-
-    }
-
-    @Test
-    void shouldConvertDocumentEntityFromEntity() {
-
-        var entity = converter.toCommunication(actor);
-        assertEquals("Actor", entity.name());
-        assertEquals(6, entity.size());
-
-        assertThat(entity.elements()).contains(documents);
-    }
-
-    @Test
-    void shouldConvertDocumentEntityToEntity() {
-        var entity = CommunicationEntity.of("Actor");
-        Stream.of(documents).forEach(entity::add);
-
-        Actor actor = converter.toEntity(Actor.class, entity);
-        assertNotNull(actor);
-        assertEquals(10, actor.getAge());
-        assertEquals(12L, actor.getId());
-        assertEquals(asList("234", "2342"), actor.getPhones());
-        assertEquals(Collections.singletonMap("JavaZone", "Jedi"), actor.getMovieCharacter());
-        assertEquals(Collections.singletonMap("JavaZone", 10), actor.getMovieRating());
-    }
-
-    @Test
-    void shouldConvertDocumentEntityToEntity2() {
-        var entity = CommunicationEntity.of("Actor");
-        Stream.of(documents).forEach(entity::add);
-
-        Actor actor = converter.toEntity(entity);
-        assertNotNull(actor);
-        assertEquals(10, actor.getAge());
-        assertEquals(12L, actor.getId());
-        assertEquals(asList("234", "2342"), actor.getPhones());
-        assertEquals(Collections.singletonMap("JavaZone", "Jedi"), actor.getMovieCharacter());
-        assertEquals(Collections.singletonMap("JavaZone", 10), actor.getMovieRating());
-    }
-
-    @Test
-    void shouldConvertDocumentEntityToExistEntity() {
-        var entity = CommunicationEntity.of("Actor");
-        Stream.of(documents).forEach(entity::add);
-        Actor actor = Actor.actorBuilder().build();
-        Actor result = converter.toEntity(actor, entity);
-
-        assertSame(actor, result);
-        assertEquals(10, actor.getAge());
-        assertEquals(12L, actor.getId());
-        assertEquals(asList("234", "2342"), actor.getPhones());
-        assertEquals(Collections.singletonMap("JavaZone", "Jedi"), actor.getMovieCharacter());
-        assertEquals(Collections.singletonMap("JavaZone", 10), actor.getMovieRating());
-    }
-
-    @Test
-    void shouldReturnErrorWhenToEntityIsNull() {
-        var entity = CommunicationEntity.of("Actor");
-        Stream.of(documents).forEach(entity::add);
-        Actor actor = Actor.actorBuilder().build();
-
-        assertThrows(NullPointerException.class, () -> converter.toEntity(null, entity));
-
-        assertThrows(NullPointerException.class, () -> converter.toEntity(actor, null));
-    }
-
-
-    @Test
-    void shouldConvertEntityToDocumentEntity2() {
-
-        Movie movie = new Movie("Matrix", 2012, Collections.singleton("Actor"));
-        Director director = Director.builderDirector().withAge(12)
-                .withId(12)
-                .withName("Otavio")
-                .withPhones(asList("234", "2342")).withMovie(movie).build();
-
-        var entity = converter.toCommunication(director);
-        assertEquals(5, entity.size());
-
-        assertEquals(getValue(entity.find("name")), director.getName());
-        assertEquals(getValue(entity.find("age")), director.getAge());
-        assertEquals(getValue(entity.find("_id")), director.getId());
-        assertEquals(getValue(entity.find("phones")), director.getPhones());
-
-
-        Element subDocument = entity.find("movie").get();
-        List<Element> documents = subDocument.get(new TypeReference<>() {
-        });
-
-        assertEquals(3, documents.size());
-        assertEquals("movie", subDocument.name());
-        assertEquals(movie.getTitle(), documents.stream().filter(c -> "title".equals(c.name())).findFirst().get().get());
-        assertEquals(movie.getYear(), documents.stream().filter(c -> "year".equals(c.name())).findFirst().get().get());
-        assertEquals(movie.getActors(), documents.stream().filter(c -> "actors".equals(c.name())).findFirst().get().get());
-
-
-    }
-
-    @Test
-    void shouldConvertToEmbeddedClassWhenHasSubDocument() {
-        Movie movie = new Movie("Matrix", 2012, Collections.singleton("Actor"));
-        Director director = Director.builderDirector().withAge(12)
-                .withId(12)
-                .withName("Otavio")
-                .withPhones(asList("234", "2342")).withMovie(movie).build();
-
-        CommunicationEntity entity = converter.toCommunication(director);
-        Director director1 = converter.toEntity(entity);
-
-        assertEquals(movie, director1.getMovie());
-        assertEquals(director.getName(), director1.getName());
-        assertEquals(director.getAge(), director1.getAge());
-        assertEquals(director.getId(), director1.getId());
-    }
-
-    @Test
-    void shouldConvertToEmbeddedClassWhenHasSubDocument2() {
-        Movie movie = new Movie("Matrix", 2012, singleton("Actor"));
-        Director director = Director.builderDirector().withAge(12)
-                .withId(12)
-                .withName("Otavio")
-                .withPhones(asList("234", "2342")).withMovie(movie).build();
-
-        var entity = converter.toCommunication(director);
-        entity.remove("movie");
-        entity.add(Element.of("movie", Arrays.asList(Element.of("title", "Matrix"),
-                Element.of("year", 2012), Element.of("actors", singleton("Actor")))));
-        Director director1 = converter.toEntity(entity);
-
-        assertEquals(movie, director1.getMovie());
-        assertEquals(director.getName(), director1.getName());
-        assertEquals(director.getAge(), director1.getAge());
-        assertEquals(director.getId(), director1.getId());
-    }
-
-    @Test
-    void shouldConvertToEmbeddedClassWhenHasSubDocument3() {
-        Movie movie = new Movie("Matrix", 2012, singleton("Actor"));
-        Director director = Director.builderDirector().withAge(12)
-                .withId(12)
-                .withName("Otavio")
-                .withPhones(asList("234", "2342")).withMovie(movie).build();
-
-        var entity = converter.toCommunication(director);
-        entity.remove("movie");
-        Map<String, Object> map = new HashMap<>();
-        map.put("title", "Matrix");
-        map.put("year", 2012);
-        map.put("actors", singleton("Actor"));
-
-        entity.add(Element.of("movie", map));
-        Director director1 = converter.toEntity(entity);
-
-        assertEquals(movie, director1.getMovie());
-        assertEquals(director.getName(), director1.getName());
-        assertEquals(director.getAge(), director1.getAge());
-        assertEquals(director.getId(), director1.getId());
-    }
-
-    @Test
-    void shouldConvertToDocumentWhenHaConverter() {
-        Worker worker = new Worker();
-        Job job = new Job();
-        job.setCity("Sao Paulo");
-        job.setDescription("Java Developer");
-        worker.setName("Bob");
-        worker.setSalary(new Money("BRL", BigDecimal.TEN));
-        worker.setJob(job);
-        var entity = converter.toCommunication(worker);
-        assertEquals("Worker", entity.name());
-        assertEquals("Bob", entity.find("name").get().get());
-        assertEquals("Sao Paulo", entity.find("city").get().get());
-        assertEquals("Java Developer", entity.find("description").get().get());
-        assertEquals("BRL 10", entity.find("money").get().get());
-    }
-
-    @Test
-    void shouldConvertToEntityWhenHasConverter() {
-        Worker worker = new Worker();
-        Job job = new Job();
-        job.setCity("Sao Paulo");
-        job.setDescription("Java Developer");
-        worker.setName("Bob");
-        worker.setSalary(new Money("BRL", BigDecimal.TEN));
-        worker.setJob(job);
-        var entity = converter.toCommunication(worker);
-        Worker worker1 = converter.toEntity(entity);
-        assertEquals(worker.getSalary(), worker1.getSalary());
-        assertEquals(job.getCity(), worker1.getJob().getCity());
-        assertEquals(job.getDescription(), worker1.getJob().getDescription());
-    }
-
-    @Test
-    void shouldConvertEmbeddableLazily() {
-        var entity = CommunicationEntity.of("Worker");
-        entity.add("name", "Otavio");
-        entity.add("money", "BRL 10");
-
-        Worker worker = converter.toEntity(entity);
-        assertEquals("Otavio", worker.getName());
-        assertEquals(new Money("BRL", BigDecimal.TEN), worker.getSalary());
-        Assertions.assertNull(worker.getJob());
-
-    }
-
-
-    @Test
-    void shouldConvertToListEmbeddable() {
-        AppointmentBook appointmentBook = new AppointmentBook("ids");
-        appointmentBook.add(Contact.builder().withType(ContactType.EMAIL)
-                .withName("Ada").withInformation("ada@lovelace.com").build());
-        appointmentBook.add(Contact.builder().withType(ContactType.MOBILE)
-                .withName("Ada").withInformation("11 1231231 123").build());
-        appointmentBook.add(Contact.builder().withType(ContactType.PHONE)
-                .withName("Ada").withInformation("12 123 1231 123123").build());
-
-        var entity = converter.toCommunication(appointmentBook);
-        var contacts = entity.find("contacts").get();
-        assertEquals("ids", appointmentBook.getId());
-        List<List<Element>> documents = (List<List<Element>>) contacts.get();
-
-        assertEquals(3L, documents.stream().flatMap(Collection::stream)
-                .filter(c -> c.name().equals("contact_name"))
-                .count());
-    }
-
-    @Test
-    void shouldConvertFromListEmbeddable() {
-        var entity = CommunicationEntity.of("AppointmentBook");
-        entity.add(Element.of("_id", "ids"));
-        List<List<Element>> documents = new ArrayList<>();
-
-        documents.add(asList(Element.of("contact_name", "Ada"), Element.of("type", ContactType.EMAIL),
-                Element.of("information", "ada@lovelace.com")));
-
-        documents.add(asList(Element.of("contact_name", "Ada"), Element.of("type", ContactType.MOBILE),
-                Element.of("information", "11 1231231 123")));
-
-        documents.add(asList(Element.of("contact_name", "Ada"), Element.of("type", ContactType.PHONE),
-                Element.of("information", "phone")));
-
-        entity.add(Element.of("contacts", documents));
-
-        AppointmentBook appointmentBook = converter.toEntity(entity);
-
-        List<Contact> contacts = appointmentBook.getContacts();
-        assertEquals("ids", appointmentBook.getId());
-        assertEquals("Ada", contacts.stream().map(Contact::getName).distinct().findFirst().get());
-
-    }
-
-
-    @Test
-    void shouldConvertSubEntity() {
-        ZipCode zipcode = new ZipCode();
-        zipcode.setZip("12321");
-        zipcode.setPlusFour("1234");
-
-        Address address = new Address();
-        address.setCity("Salvador");
-        address.setState("Bahia");
-        address.setStreet("Rua Engenheiro Jose Anasoh");
-        address.setZipCode(zipcode);
-
-        var documentEntity = converter.toCommunication(address);
-        List<Element> documents = documentEntity.elements();
-        assertEquals("Address", documentEntity.name());
-        assertEquals(4, documents.size());
-        List<Element> zip = documentEntity.find("zipCode").map(d -> d.get(new TypeReference<List<Element>>() {
-        })).orElse(Collections.emptyList());
-
-        assertEquals("Rua Engenheiro Jose Anasoh", getValue(documentEntity.find("street")));
-        assertEquals("Salvador", getValue(documentEntity.find("city")));
-        assertEquals("Bahia", getValue(documentEntity.find("state")));
-        assertEquals("12321", getValue(zip.stream().filter(d -> d.name().equals("zip")).findFirst()));
-        assertEquals("1234", getValue(zip.stream().filter(d -> d.name().equals("plusFour")).findFirst()));
-    }
-
-    @Test
-    void shouldConvertDocumentInSubEntity() {
-
-        var entity = CommunicationEntity.of("Address");
-
-        entity.add(Element.of("street", "Rua Engenheiro Jose Anasoh"));
-        entity.add(Element.of("city", "Salvador"));
-        entity.add(Element.of("state", "Bahia"));
-        entity.add(Element.of("zipCode", Arrays.asList(
-                Element.of("zip", "12321"),
-                Element.of("plusFour", "1234"))));
-        Address address = converter.toEntity(entity);
-
-        assertEquals("Rua Engenheiro Jose Anasoh", address.getStreet());
-        assertEquals("Salvador", address.getCity());
-        assertEquals("Bahia", address.getState());
-        assertEquals("12321", address.getZipCode().getZip());
-        assertEquals("1234", address.getZipCode().getPlusFour());
-
-    }
-
-    @Test
-    void shouldReturnNullWhenThereIsNotSubEntity() {
-        var entity = CommunicationEntity.of("Address");
-
-        entity.add(Element.of("street", "Rua Engenheiro Jose Anasoh"));
-        entity.add(Element.of("city", "Salvador"));
-        entity.add(Element.of("state", "Bahia"));
-        entity.add(Element.of("zip", "12321"));
-        entity.add(Element.of("plusFour", "1234"));
-
-        Address address = converter.toEntity(entity);
-
-        assertEquals("Rua Engenheiro Jose Anasoh", address.getStreet());
-        assertEquals("Salvador", address.getCity());
-        assertEquals("Bahia", address.getState());
-        assertNull(address.getZipCode());
-    }
-
-    @Test
-    void shouldConvertAndDoNotUseUnmodifiableCollection() {
-        var entity = CommunicationEntity.of("vendors");
-        entity.add("name", "name");
-        entity.add("prefixes", Arrays.asList("value", "value2"));
-
-        Vendor vendor = converter.toEntity(entity);
-        vendor.add("value3");
-
-        Assertions.assertEquals(3, vendor.getPrefixes().size());
-
-    }
-
-    @Test
-    void shouldConvertEntityToDocumentWithArray() {
-        byte[] contents = {1, 2, 3, 4, 5, 6};
-
-        var entity = CommunicationEntity.of("download");
-        entity.add("_id", 1L);
-        entity.add("contents", contents);
-
-        Download download = converter.toEntity(entity);
-        Assertions.assertEquals(1L, download.getId());
-        Assertions.assertArrayEquals(contents, download.getContents());
-    }
-
-    @Test
-    void shouldConvertDocumentToEntityWithArray() {
-        byte[] contents = {1, 2, 3, 4, 5, 6};
-
-        Download download = new Download();
-        download.setId(1L);
-        download.setContents(contents);
-
-        var entity = converter.toCommunication(download);
-
-        Assertions.assertEquals(1L, entity.find("_id").get().get());
-        final byte[] bytes = entity.find("contents").map(v -> v.get(byte[].class)).orElse(new byte[0]);
-        Assertions.assertArrayEquals(contents, bytes);
-    }
-
-    @Test
-    void shouldCreateUserScope() {
-        var entity = CommunicationEntity.of("UserScope");
-        entity.add("_id", "userName");
-        entity.add("scope", "scope");
-        entity.add("properties", Collections.singletonList(Element.of("halo", "weld")));
-
-        UserScope user = converter.toEntity(entity);
-        Assertions.assertNotNull(user);
-        Assertions.assertEquals("userName",user.getUserName());
-        Assertions.assertEquals("scope",user.getScope());
-        Assertions.assertEquals(Collections.singletonMap("halo", "weld"),user.getProperties());
-
-    }
-
-    @Test
-    void shouldCreateUserScope2() {
-        var entity = CommunicationEntity.of("UserScope");
-        entity.add("_id", "userName");
-        entity.add("scope", "scope");
-        entity.add("properties", Element.of("halo", "weld"));
-
-        UserScope user = converter.toEntity(entity);
-        Assertions.assertNotNull(user);
-        Assertions.assertEquals("userName",user.getUserName());
-        Assertions.assertEquals("scope",user.getScope());
-        Assertions.assertEquals(Collections.singletonMap("halo", "weld"),user.getProperties());
-
-    }
-
-    @Test
-    void shouldCreateLazilyEntity() {
-        var entity = CommunicationEntity.of("Citizen");
-        entity.add("id", "10");
-        entity.add("name", "Salvador");
-
-        Citizen citizen = converter.toEntity(entity);
-        Assertions.assertNotNull(citizen);
-        Assertions.assertNull(citizen.getCity());
-    }
-
-    @Test
-    void shouldConvertGroupEmbeddable(){
-        CommunicationEntity entity = CommunicationEntity.of("Wine");
-        entity.add("_id", "id");
-        entity.add("name", "Vin Blanc");
-        entity.add("factory", List.of(Element.of("name", "Napa Valley Factory"),
-                Element.of("location", "Napa Valley")));
-
-        Wine wine = converter.toEntity(entity);
-
-        SoftAssertions.assertSoftly(soft ->{
-            WineFactory factory = wine.getFactory();
-            soft.assertThat(wine).isNotNull();
-            soft.assertThat(wine.getId()).isEqualTo("id");
-            soft.assertThat(wine.getName()).isEqualTo("Vin Blanc");
-            soft.assertThat(factory).isNotNull();
-            soft.assertThat(factory.getName()).isEqualTo("Napa Valley Factory");
-            soft.assertThat(factory.getLocation()).isEqualTo("Napa Valley");
-        });
-    }
-
-    @Test
-    void shouldConvertGroupEmbeddableToCommunication(){
-
-        Wine wine = Wine.of("id", "Vin Blanc", WineFactory.of("Napa Valley Factory", "Napa Valley"));
-
-
-        var communication = converter.toCommunication(wine);
-
-        SoftAssertions.assertSoftly(soft ->{
-            soft.assertThat(communication).isNotNull();
-            soft.assertThat(communication.name()).isEqualTo("Wine");
-            soft.assertThat(communication.find("_id").orElseThrow().get()).isEqualTo("id");
-            soft.assertThat(communication.find("name").orElseThrow().get()).isEqualTo("Vin Blanc");
-            communication.find("factory").ifPresent(e -> {
-                List<Element> elements = e.get(new TypeReference<>(){});
-                soft.assertThat(elements).hasSize(2);
-                soft.assertThat(elements.stream().filter(c -> "name".equals(c.name())).findFirst().orElseThrow().get())
-                        .isEqualTo("Napa Valley Factory");
-                soft.assertThat(elements.stream().filter(c -> "location".equals(c.name())).findFirst().orElseThrow().get())
-                        .isEqualTo("Napa Valley");
+    @Nested
+    @DisplayName("When converting entities")
+    class WhenTheConversion {
+
+        @Test
+        @DisplayName("Should convert Entity From Document Entity")
+        void shouldConvertEntityFromDocumentEntity() {
+
+            Person person = Person.builder().withAge()
+                    .withId(12)
+                    .withName("Otavio")
+                    .withPhones(asList("234", "2342")).build();
+
+            var entity = converter.toCommunication(person);
+            assertThat(entity.name()).isEqualTo("Person");
+            assertThat(entity.size()).isEqualTo(4);
+            assertThat(entity.elements()).contains(Element.of("_id", 12L),
+                    Element.of("age", 10), Element.of("name", "Otavio"),
+                    Element.of("phones", Arrays.asList("234", "2342")));
+
+        }
+
+        @Test
+        @DisplayName("Should convert Document Entity From Entity")
+        void shouldConvertDocumentEntityFromEntity() {
+
+            var entity = converter.toCommunication(actor);
+            assertThat(entity.name()).isEqualTo("Actor");
+            assertThat(entity.size()).isEqualTo(6);
+
+            assertThat(entity.elements()).contains(documents);
+        }
+
+        @Test
+        @DisplayName("Should convert Document Entity To Entity")
+        void shouldConvertDocumentEntityToEntity() {
+            var entity = CommunicationEntity.of("Actor");
+            Stream.of(documents).forEach(entity::add);
+
+            Actor actor = converter.toEntity(Actor.class, entity);
+            assertThat(actor).isNotNull();
+            assertThat(actor.getAge()).isEqualTo(10);
+            assertThat(actor.getId()).isEqualTo(12L);
+            assertThat(actor.getPhones()).isEqualTo(asList("234", "2342"));
+            assertThat(actor.getMovieCharacter()).isEqualTo(Collections.singletonMap("JavaZone", "Jedi"));
+            assertThat(actor.getMovieRating()).isEqualTo(Collections.singletonMap("JavaZone", 10));
+        }
+
+        @Test
+        @DisplayName("Should convert to entity without explicit type")
+        void shouldConvertToEntityWithoutExplicitType() {
+            var entity = CommunicationEntity.of("Actor");
+            Stream.of(documents).forEach(entity::add);
+
+            Actor actor = converter.toEntity(entity);
+            assertThat(actor).isNotNull();
+            assertThat(actor.getAge()).isEqualTo(10);
+            assertThat(actor.getId()).isEqualTo(12L);
+            assertThat(actor.getPhones()).isEqualTo(asList("234", "2342"));
+            assertThat(actor.getMovieCharacter()).isEqualTo(Collections.singletonMap("JavaZone", "Jedi"));
+            assertThat(actor.getMovieRating()).isEqualTo(Collections.singletonMap("JavaZone", 10));
+        }
+
+        @Test
+        @DisplayName("Should convert Document Entity To Exist Entity")
+        void shouldConvertDocumentEntityToExistEntity() {
+            var entity = CommunicationEntity.of("Actor");
+            Stream.of(documents).forEach(entity::add);
+            Actor actor = Actor.actorBuilder().build();
+            Actor result = converter.toEntity(actor, entity);
+
+            assertThat(result).isSameAs(actor);
+            assertThat(actor.getAge()).isEqualTo(10);
+            assertThat(actor.getId()).isEqualTo(12L);
+            assertThat(actor.getPhones()).isEqualTo(asList("234", "2342"));
+            assertThat(actor.getMovieCharacter()).isEqualTo(Collections.singletonMap("JavaZone", "Jedi"));
+            assertThat(actor.getMovieRating()).isEqualTo(Collections.singletonMap("JavaZone", 10));
+        }
+
+        @Test
+        @DisplayName("Should return an error when entity conversion receives null")
+        void shouldReturnErrorWhenToEntityIsNull() {
+            var entity = CommunicationEntity.of("Actor");
+            Stream.of(documents).forEach(entity::add);
+            Actor actor = Actor.actorBuilder().build();
+
+            assertThatNullPointerException().isThrownBy(() -> converter.toEntity(null, entity));
+
+            assertThatNullPointerException().isThrownBy(() -> converter.toEntity(actor, null));
+        }
+
+
+        @Test
+        @DisplayName("Should convert an entity with an embedded movie")
+        void shouldConvertEntityWithEmbeddedMovie() {
+
+            Movie movie = new Movie("Matrix", 2012, Collections.singleton("Actor"));
+            Director director = Director.builderDirector().withAge(12)
+                    .withId(12)
+                    .withName("Otavio")
+                    .withPhones(asList("234", "2342")).withMovie(movie).build();
+
+            var entity = converter.toCommunication(director);
+            assertThat(entity.size()).isEqualTo(5);
+
+            assertThat(director.getName()).isEqualTo(getValue(entity.find("name")));
+            assertThat(director.getAge()).isEqualTo(getValue(entity.find("age")));
+            assertThat(director.getId()).isEqualTo(getValue(entity.find("_id")));
+            assertThat(director.getPhones()).isEqualTo(getValue(entity.find("phones")));
+
+
+            Element subDocument = entity.find("movie").get();
+            List<Element> documents = subDocument.get(new TypeReference<>() {
             });
 
-        });
-    }
+            assertThat(documents.size()).isEqualTo(3);
+            assertThat(subDocument.name()).isEqualTo("movie");
+            assertThat(documents.stream().filter(c -> "title".equals(c.name())).findFirst().get().get()).isEqualTo(movie.getTitle());
+            assertThat(documents.stream().filter(c -> "year".equals(c.name())).findFirst().get().get()).isEqualTo(movie.getYear());
+            assertThat(documents.stream().filter(c -> "actors".equals(c.name())).findFirst().get().get()).isEqualTo(movie.getActors());
 
+
+        }
+
+        @Test
+        @DisplayName("Should convert an embedded class from a document")
+        void shouldConvertToEmbeddedClassWhenHasSubDocument() {
+            Movie movie = new Movie("Matrix", 2012, Collections.singleton("Actor"));
+            Director director = Director.builderDirector().withAge(12)
+                    .withId(12)
+                    .withName("Otavio")
+                    .withPhones(asList("234", "2342")).withMovie(movie).build();
+
+            CommunicationEntity entity = converter.toCommunication(director);
+            Director director1 = converter.toEntity(entity);
+
+            assertThat(director1.getMovie()).isEqualTo(movie);
+            assertThat(director1.getName()).isEqualTo(director.getName());
+            assertThat(director1.getAge()).isEqualTo(director.getAge());
+            assertThat(director1.getId()).isEqualTo(director.getId());
+        }
+
+        @Test
+        @DisplayName("Should convert an embedded class from element list")
+        void shouldConvertEmbeddedClassFromElementList() {
+            Movie movie = new Movie("Matrix", 2012, singleton("Actor"));
+            Director director = Director.builderDirector().withAge(12)
+                    .withId(12)
+                    .withName("Otavio")
+                    .withPhones(asList("234", "2342")).withMovie(movie).build();
+
+            var entity = converter.toCommunication(director);
+            entity.remove("movie");
+            entity.add(Element.of("movie", Arrays.asList(Element.of("title", "Matrix"),
+                    Element.of("year", 2012), Element.of("actors", singleton("Actor")))));
+            Director director1 = converter.toEntity(entity);
+
+            assertThat(director1.getMovie()).isEqualTo(movie);
+            assertThat(director1.getName()).isEqualTo(director.getName());
+            assertThat(director1.getAge()).isEqualTo(director.getAge());
+            assertThat(director1.getId()).isEqualTo(director.getId());
+        }
+
+        @Test
+        @DisplayName("Should convert an embedded class from map")
+        void shouldConvertEmbeddedClassFromMap() {
+            Movie movie = new Movie("Matrix", 2012, singleton("Actor"));
+            Director director = Director.builderDirector().withAge(12)
+                    .withId(12)
+                    .withName("Otavio")
+                    .withPhones(asList("234", "2342")).withMovie(movie).build();
+
+            var entity = converter.toCommunication(director);
+            entity.remove("movie");
+            Map<String, Object> map = new HashMap<>();
+            map.put("title", "Matrix");
+            map.put("year", 2012);
+            map.put("actors", singleton("Actor"));
+
+            entity.add(Element.of("movie", map));
+            Director director1 = converter.toEntity(entity);
+
+            assertThat(director1.getMovie()).isEqualTo(movie);
+            assertThat(director1.getName()).isEqualTo(director.getName());
+            assertThat(director1.getAge()).isEqualTo(director.getAge());
+            assertThat(director1.getId()).isEqualTo(director.getId());
+        }
+
+        @Test
+        @DisplayName("Should convert To Document When has Converter")
+        void shouldConvertToDocumentWhenHaConverter() {
+            Worker worker = new Worker();
+            Job job = new Job();
+            job.setCity("Sao Paulo");
+            job.setDescription("Java Developer");
+            worker.setName("Bob");
+            worker.setSalary(new Money("BRL", BigDecimal.TEN));
+            worker.setJob(job);
+            var entity = converter.toCommunication(worker);
+            assertThat(entity.name()).isEqualTo("Worker");
+            assertThat(entity.find("name").get().get()).isEqualTo("Bob");
+            assertThat(entity.find("city").get().get()).isEqualTo("Sao Paulo");
+            assertThat(entity.find("description").get().get()).isEqualTo("Java Developer");
+            assertThat(entity.find("money").get().get()).isEqualTo("BRL 10");
+        }
+
+        @Test
+        @DisplayName("Should convert To Entity When Has Converter")
+        void shouldConvertToEntityWhenHasConverter() {
+            Worker worker = new Worker();
+            Job job = new Job();
+            job.setCity("Sao Paulo");
+            job.setDescription("Java Developer");
+            worker.setName("Bob");
+            worker.setSalary(new Money("BRL", BigDecimal.TEN));
+            worker.setJob(job);
+            var entity = converter.toCommunication(worker);
+            Worker worker1 = converter.toEntity(entity);
+            assertThat(worker1.getSalary()).isEqualTo(worker.getSalary());
+            assertThat(worker1.getJob().getCity()).isEqualTo(job.getCity());
+            assertThat(worker1.getJob().getDescription()).isEqualTo(job.getDescription());
+        }
+
+        @Test
+        @DisplayName("Should convert Embeddable Lazily")
+        void shouldConvertEmbeddableLazily() {
+            var entity = CommunicationEntity.of("Worker");
+            entity.add("name", "Otavio");
+            entity.add("money", "BRL 10");
+
+            Worker worker = converter.toEntity(entity);
+            assertThat(worker.getName()).isEqualTo("Otavio");
+            assertThat(worker.getSalary()).isEqualTo(new Money("BRL", BigDecimal.TEN));
+            assertThat(worker.getJob()).isNull();
+
+        }
+
+
+        @Test
+        @DisplayName("Should convert To List Embeddable")
+        void shouldConvertToListEmbeddable() {
+            AppointmentBook appointmentBook = new AppointmentBook("ids");
+            appointmentBook.add(Contact.builder().withType(ContactType.EMAIL)
+                    .withName("Ada").withInformation("ada@lovelace.com").build());
+            appointmentBook.add(Contact.builder().withType(ContactType.MOBILE)
+                    .withName("Ada").withInformation("11 1231231 123").build());
+            appointmentBook.add(Contact.builder().withType(ContactType.PHONE)
+                    .withName("Ada").withInformation("12 123 1231 123123").build());
+
+            var entity = converter.toCommunication(appointmentBook);
+            var contacts = entity.find("contacts").get();
+            assertThat(appointmentBook.getId()).isEqualTo("ids");
+            List<List<Element>> documents = (List<List<Element>>) contacts.get();
+
+            assertThat(documents.stream().flatMap(Collection::stream)
+                    .filter(c -> c.name().equals("contact_name"))
+                    .count()).isEqualTo(3L);
+        }
+
+        @Test
+        @DisplayName("Should convert From List Embeddable")
+        void shouldConvertFromListEmbeddable() {
+            var entity = CommunicationEntity.of("AppointmentBook");
+            entity.add(Element.of("_id", "ids"));
+            List<List<Element>> documents = new ArrayList<>();
+
+            documents.add(asList(Element.of("contact_name", "Ada"), Element.of("type", ContactType.EMAIL),
+                    Element.of("information", "ada@lovelace.com")));
+
+            documents.add(asList(Element.of("contact_name", "Ada"), Element.of("type", ContactType.MOBILE),
+                    Element.of("information", "11 1231231 123")));
+
+            documents.add(asList(Element.of("contact_name", "Ada"), Element.of("type", ContactType.PHONE),
+                    Element.of("information", "phone")));
+
+            entity.add(Element.of("contacts", documents));
+
+            AppointmentBook appointmentBook = converter.toEntity(entity);
+
+            List<Contact> contacts = appointmentBook.getContacts();
+            assertThat(appointmentBook.getId()).isEqualTo("ids");
+            assertThat(contacts.stream().map(Contact::getName).distinct().findFirst().get()).isEqualTo("Ada");
+
+        }
+
+
+        @Test
+        @DisplayName("Should convert Sub Entity")
+        void shouldConvertSubEntity() {
+            ZipCode zipcode = new ZipCode();
+            zipcode.setZip("12321");
+            zipcode.setPlusFour("1234");
+
+            Address address = new Address();
+            address.setCity("Salvador");
+            address.setState("Bahia");
+            address.setStreet("Rua Engenheiro Jose Anasoh");
+            address.setZipCode(zipcode);
+
+            var documentEntity = converter.toCommunication(address);
+            List<Element> documents = documentEntity.elements();
+            assertThat(documentEntity.name()).isEqualTo("Address");
+            assertThat(documents.size()).isEqualTo(4);
+            List<Element> zip = documentEntity.find("zipCode").map(d -> d.get(new TypeReference<List<Element>>() {
+            })).orElse(Collections.emptyList());
+
+            assertThat(getValue(documentEntity.find("street"))).isEqualTo("Rua Engenheiro Jose Anasoh");
+            assertThat(getValue(documentEntity.find("city"))).isEqualTo("Salvador");
+            assertThat(getValue(documentEntity.find("state"))).isEqualTo("Bahia");
+            assertThat(getValue(zip.stream().filter(d -> d.name().equals("zip")).findFirst())).isEqualTo("12321");
+            assertThat(getValue(zip.stream().filter(d -> d.name().equals("plusFour")).findFirst())).isEqualTo("1234");
+        }
+
+        @Test
+        @DisplayName("Should convert Document In Sub Entity")
+        void shouldConvertDocumentInSubEntity() {
+
+            var entity = CommunicationEntity.of("Address");
+
+            entity.add(Element.of("street", "Rua Engenheiro Jose Anasoh"));
+            entity.add(Element.of("city", "Salvador"));
+            entity.add(Element.of("state", "Bahia"));
+            entity.add(Element.of("zipCode", Arrays.asList(
+                    Element.of("zip", "12321"),
+                    Element.of("plusFour", "1234"))));
+            Address address = converter.toEntity(entity);
+
+            assertThat(address.getStreet()).isEqualTo("Rua Engenheiro Jose Anasoh");
+            assertThat(address.getCity()).isEqualTo("Salvador");
+            assertThat(address.getState()).isEqualTo("Bahia");
+            assertThat(address.getZipCode().getZip()).isEqualTo("12321");
+            assertThat(address.getZipCode().getPlusFour()).isEqualTo("1234");
+
+        }
+
+        @Test
+        @DisplayName("Should return Null When There Is Not Sub Entity")
+        void shouldReturnNullWhenThereIsNotSubEntity() {
+            var entity = CommunicationEntity.of("Address");
+
+            entity.add(Element.of("street", "Rua Engenheiro Jose Anasoh"));
+            entity.add(Element.of("city", "Salvador"));
+            entity.add(Element.of("state", "Bahia"));
+            entity.add(Element.of("zip", "12321"));
+            entity.add(Element.of("plusFour", "1234"));
+
+            Address address = converter.toEntity(entity);
+
+            assertThat(address.getStreet()).isEqualTo("Rua Engenheiro Jose Anasoh");
+            assertThat(address.getCity()).isEqualTo("Salvador");
+            assertThat(address.getState()).isEqualTo("Bahia");
+            assertThat(address.getZipCode()).isNull();
+        }
+
+        @Test
+        @DisplayName("Should convert And does not Use Unmodifiable Collection")
+        void shouldConvertAndDoNotUseUnmodifiableCollection() {
+            var entity = CommunicationEntity.of("vendors");
+            entity.add("name", "name");
+            entity.add("prefixes", Arrays.asList("value", "value2"));
+
+            Vendor vendor = converter.toEntity(entity);
+            vendor.add("value3");
+
+            assertThat(vendor.getPrefixes().size()).isEqualTo(3);
+
+        }
+
+        @Test
+        @DisplayName("Should convert Entity To Document With Array")
+        void shouldConvertEntityToDocumentWithArray() {
+            byte[] contents = {1, 2, 3, 4, 5, 6};
+
+            var entity = CommunicationEntity.of("download");
+            entity.add("_id", 1L);
+            entity.add("contents", contents);
+
+            Download download = converter.toEntity(entity);
+            assertThat(download.getId()).isEqualTo(1L);
+            assertThat(download.getContents()).containsExactly(contents);
+        }
+
+        @Test
+        @DisplayName("Should convert Document To Entity With Array")
+        void shouldConvertDocumentToEntityWithArray() {
+            byte[] contents = {1, 2, 3, 4, 5, 6};
+
+            Download download = new Download();
+            download.setId(1L);
+            download.setContents(contents);
+
+            var entity = converter.toCommunication(download);
+
+            assertThat(entity.find("_id").get().get()).isEqualTo(1L);
+            final byte[] bytes = entity.find("contents").map(v -> v.get(byte[].class)).orElse(new byte[0]);
+            assertThat(bytes).containsExactly(contents);
+        }
+
+        @Test
+        @DisplayName("Should create user scope from a collection")
+        void shouldCreateUserScope() {
+            var entity = CommunicationEntity.of("UserScope");
+            entity.add("_id", "userName");
+            entity.add("scope", "scope");
+            entity.add("properties", Collections.singletonList(Element.of("halo", "weld")));
+
+            UserScope user = converter.toEntity(entity);
+            assertThat(user).isNotNull();
+            assertThat(user.getUserName()).isEqualTo("userName");
+            assertThat(user.getScope()).isEqualTo("scope");
+            assertThat(user.getProperties()).isEqualTo(Collections.singletonMap("halo", "weld"));
+
+        }
+
+        @Test
+        @DisplayName("Should create user scope from an element")
+        void shouldCreateUserScopeFromElement() {
+            var entity = CommunicationEntity.of("UserScope");
+            entity.add("_id", "userName");
+            entity.add("scope", "scope");
+            entity.add("properties", Element.of("halo", "weld"));
+
+            UserScope user = converter.toEntity(entity);
+            assertThat(user).isNotNull();
+            assertThat(user.getUserName()).isEqualTo("userName");
+            assertThat(user.getScope()).isEqualTo("scope");
+            assertThat(user.getProperties()).isEqualTo(Collections.singletonMap("halo", "weld"));
+
+        }
+
+        @Test
+        @DisplayName("Should create Lazily Entity")
+        void shouldCreateLazilyEntity() {
+            var entity = CommunicationEntity.of("Citizen");
+            entity.add("id", "10");
+            entity.add("name", "Salvador");
+
+            Citizen citizen = converter.toEntity(entity);
+            assertThat(citizen).isNotNull();
+            assertThat(citizen.getCity()).isNull();
+        }
+
+        @Test
+        @DisplayName("Should convert Group Embeddable")
+        void shouldConvertGroupEmbeddable(){
+            CommunicationEntity entity = CommunicationEntity.of("Wine");
+            entity.add("_id", "id");
+            entity.add("name", "Vin Blanc");
+            entity.add("factory", List.of(Element.of("name", "Napa Valley Factory"),
+                    Element.of("location", "Napa Valley")));
+
+            Wine wine = converter.toEntity(entity);
+
+            assertSoftly(soft ->{
+                WineFactory factory = wine.getFactory();
+                soft.assertThat(wine).as("wine").isNotNull();
+                soft.assertThat(wine.getId()).as("wine id").isEqualTo("id");
+                soft.assertThat(wine.getName()).as("wine name").isEqualTo("Vin Blanc");
+                soft.assertThat(factory).as("wine factory").isNotNull();
+                soft.assertThat(factory.getName()).as("factory name").isEqualTo("Napa Valley Factory");
+                soft.assertThat(factory.getLocation()).as("factory location").isEqualTo("Napa Valley");
+            });
+        }
+
+        @Test
+        @DisplayName("Should convert Group Embeddable To Communication")
+        void shouldConvertGroupEmbeddableToCommunication(){
+
+            Wine wine = Wine.of("id", "Vin Blanc", WineFactory.of("Napa Valley Factory", "Napa Valley"));
+
+
+            var communication = converter.toCommunication(wine);
+
+            assertSoftly(soft ->{
+                soft.assertThat(communication).as("communication entity").isNotNull();
+                soft.assertThat(communication.name()).as("entity name").isEqualTo("Wine");
+                soft.assertThat(communication.find("_id").orElseThrow().get()).as("identifier element").isEqualTo("id");
+                soft.assertThat(communication.find("name").orElseThrow().get()).as("name element").isEqualTo("Vin Blanc");
+                communication.find("factory").ifPresent(e -> {
+                    List<Element> elements = e.get(new TypeReference<>(){});
+                    soft.assertThat(elements).as("factory elements").hasSize(2);
+                    soft.assertThat(elements.stream().filter(c -> "name".equals(c.name())).findFirst().orElseThrow().get())
+                            .as("factory name element")
+                            .isEqualTo("Napa Valley Factory");
+                    soft.assertThat(elements.stream().filter(c -> "location".equals(c.name())).findFirst().orElseThrow().get())
+                            .as("factory location element")
+                            .isEqualTo("Napa Valley");
+                });
+
+            });
+        }
+
+
+    }
 
     private Object getValue(Optional<Element> document) {
         return document.map(Element::value).map(Value::get).orElse(null);


### PR DESCRIPTION
This pull request refactors and improves the test suite for `ColumnEntityConverterInheritanceTest`. The main focus is on enhancing readability, maintainability, and clarity of test cases. The changes introduce nested test classes with descriptive display names, replace JUnit assertions with AssertJ for more expressive assertions, and add or improve test documentation.

**Test improvements and refactoring:**

* All JUnit `Assertions` and `assertEquals`/`assertNotNull` calls are replaced with AssertJ's fluent assertions (e.g., `assertThat`, `assertThatExceptionOfType`) for better readability and error messages. [[1]](diffhunk://#diff-3d4cddfeb48cb6d63d381f8f9040bb992ee8ad55f7bb44948927d7d0e41de2c9L49-R50) [[2]](diffhunk://#diff-3d4cddfeb48cb6d63d381f8f9040bb992ee8ad55f7bb44948927d7d0e41de2c9R61-R144) [[3]](diffhunk://#diff-3d4cddfeb48cb6d63d381f8f9040bb992ee8ad55f7bb44948927d7d0e41de2c9L142-R161) [[4]](diffhunk://#diff-3d4cddfeb48cb6d63d381f8f9040bb992ee8ad55f7bb44948927d7d0e41de2c9L158-R178) [[5]](diffhunk://#diff-3d4cddfeb48cb6d63d381f8f9040bb992ee8ad55f7bb44948927d7d0e41de2c9L174-R258) [[6]](diffhunk://#diff-3d4cddfeb48cb6d63d381f8f9040bb992ee8ad55f7bb44948927d7d0e41de2c9L249-R273) [[7]](diffhunk://#diff-3d4cddfeb48cb6d63d381f8f9040bb992ee8ad55f7bb44948927d7d0e41de2c9L268-R300) [[8]](diffhunk://#diff-3d4cddfeb48cb6d63d381f8f9040bb992ee8ad55f7bb44948927d7d0e41de2c9L294-R327) [[9]](diffhunk://#diff-3d4cddfeb48cb6d63d381f8f9040bb992ee8ad55f7bb44948927d7d0e41de2c9L320-R367)
* Test methods are grouped within a `@Nested` class (`WhenTheConversion`) with descriptive `@DisplayName` annotations, making the test output more understandable and organized.
* Each test method now includes a `@DisplayName` annotation, providing clear descriptions of the test's purpose. [[1]](diffhunk://#diff-3d4cddfeb48cb6d63d381f8f9040bb992ee8ad55f7bb44948927d7d0e41de2c9R61-R144) [[2]](diffhunk://#diff-3d4cddfeb48cb6d63d381f8f9040bb992ee8ad55f7bb44948927d7d0e41de2c9L142-R161) [[3]](diffhunk://#diff-3d4cddfeb48cb6d63d381f8f9040bb992ee8ad55f7bb44948927d7d0e41de2c9L158-R178) [[4]](diffhunk://#diff-3d4cddfeb48cb6d63d381f8f9040bb992ee8ad55f7bb44948927d7d0e41de2c9L174-R258) [[5]](diffhunk://#diff-3d4cddfeb48cb6d63d381f8f9040bb992ee8ad55f7bb44948927d7d0e41de2c9L249-R273) [[6]](diffhunk://#diff-3d4cddfeb48cb6d63d381f8f9040bb992ee8ad55f7bb44948927d7d0e41de2c9L268-R300) [[7]](diffhunk://#diff-3d4cddfeb48cb6d63d381f8f9040bb992ee8ad55f7bb44948927d7d0e41de2c9L294-R327) [[8]](diffhunk://#diff-3d4cddfeb48cb6d63d381f8f9040bb992ee8ad55f7bb44948927d7d0e41de2c9L320-R367)
* Error handling tests now use `assertThatExceptionOfType(MappingException.class)` for clearer exception assertions. [[1]](diffhunk://#diff-3d4cddfeb48cb6d63d381f8f9040bb992ee8ad55f7bb44948927d7d0e41de2c9L49-R50) [[2]](diffhunk://#diff-3d4cddfeb48cb6d63d381f8f9040bb992ee8ad55f7bb44948927d7d0e41de2c9L174-R258) [[3]](diffhunk://#diff-3d4cddfeb48cb6d63d381f8f9040bb992ee8ad55f7bb44948927d7d0e41de2c9L249-R273)
* Minor renaming of test methods for clarity and consistency, e.g., `shouldConvertSocialCommunication` to `shouldConvertSocialNotificationReaderToCommunication`.

These changes collectively make the test suite more robust, maintainable, and easier to understand for future contributors.