### PR TITLE
docs: update license headers to Eclipse Public License 2.0

### DIFF
--- a/jnosql-data-tck-runner/pom.xml
+++ b/jnosql-data-tck-runner/pom.xml
@@ -3,10 +3,10 @@
   ~
   ~  Copyright (c) 2024 Contributors to the Eclipse Foundation
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-data-tck-runner/src/test/java/org/eclipse/jnosql/tck/DocumentDatabase.java
+++ b/jnosql-data-tck-runner/src/test/java/org/eclipse/jnosql/tck/DocumentDatabase.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-data-tck-runner/src/test/java/org/eclipse/jnosql/tck/JNoSQLEntityTests.java
+++ b/jnosql-data-tck-runner/src/test/java/org/eclipse/jnosql/tck/JNoSQLEntityTests.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-data-tck-runner/src/test/java/org/eclipse/jnosql/tck/JNoSQLJakartaEventBuiltInRepositoryTest.java
+++ b/jnosql-data-tck-runner/src/test/java/org/eclipse/jnosql/tck/JNoSQLJakartaEventBuiltInRepositoryTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-data-tck-runner/src/test/java/org/eclipse/jnosql/tck/JNoSQLJakartaEventCustomRepositoryTest.java
+++ b/jnosql-data-tck-runner/src/test/java/org/eclipse/jnosql/tck/JNoSQLJakartaEventCustomRepositoryTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-data-tck-runner/src/test/java/org/eclipse/jnosql/tck/JNoSQLJakartaQueryDeleteTests.java
+++ b/jnosql-data-tck-runner/src/test/java/org/eclipse/jnosql/tck/JNoSQLJakartaQueryDeleteTests.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-data-tck-runner/src/test/java/org/eclipse/jnosql/tck/JNoSQLJakartaQueryTests.java
+++ b/jnosql-data-tck-runner/src/test/java/org/eclipse/jnosql/tck/JNoSQLJakartaQueryTests.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-data-tck-runner/src/test/java/org/eclipse/jnosql/tck/JNoSQLJakartaQueryUpdateTests.java
+++ b/jnosql-data-tck-runner/src/test/java/org/eclipse/jnosql/tck/JNoSQLJakartaQueryUpdateTests.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-data-tck-runner/src/test/java/org/eclipse/jnosql/tck/JNoSQLNoSQLEntityTests.java
+++ b/jnosql-data-tck-runner/src/test/java/org/eclipse/jnosql/tck/JNoSQLNoSQLEntityTests.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-data-tck-runner/src/test/java/org/eclipse/jnosql/tck/JNoSQLRestrictionTests.java
+++ b/jnosql-data-tck-runner/src/test/java/org/eclipse/jnosql/tck/JNoSQLRestrictionTests.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/pom.xml
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/pom.xml
@@ -3,10 +3,10 @@
 ~
 ~  Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
 ~   All rights reserved. This program and the accompanying materials
-~   are made available under the terms of the Eclipse Public License v1.0
+~   are made available under the terms of the Eclipse Public License 2.0
 ~   and Apache License v2.0 which accompanies this distribution.
-~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
 ~
 ~   You may elect to redistribute this code under either of these licenses.
 ~

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/src/test/java/org/eclipse/jnosql/extensions/sql/tck/EntityManagerProducer.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/src/test/java/org/eclipse/jnosql/extensions/sql/tck/EntityManagerProducer.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/src/test/java/org/eclipse/jnosql/extensions/sql/tck/JakartaPersistenceEntityTests.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/src/test/java/org/eclipse/jnosql/extensions/sql/tck/JakartaPersistenceEntityTests.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/src/test/java/org/eclipse/jnosql/extensions/sql/tck/JakartaPersistenceQueryDeleteTests.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/src/test/java/org/eclipse/jnosql/extensions/sql/tck/JakartaPersistenceQueryDeleteTests.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  */

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/src/test/java/org/eclipse/jnosql/extensions/sql/tck/JakartaPersistenceQueryTests.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/src/test/java/org/eclipse/jnosql/extensions/sql/tck/JakartaPersistenceQueryTests.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/src/test/java/org/eclipse/jnosql/extensions/sql/tck/JakartaPersistenceQueryUpdateTests.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/src/test/java/org/eclipse/jnosql/extensions/sql/tck/JakartaPersistenceQueryUpdateTests.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/src/test/java/org/eclipse/jnosql/extensions/sql/tck/JakartaPersistenceRestrictionTests.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/src/test/java/org/eclipse/jnosql/extensions/sql/tck/JakartaPersistenceRestrictionTests.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/src/test/java/org/eclipse/jnosql/extensions/sql/tck/JakartaPersitenceEntityTests.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/src/test/java/org/eclipse/jnosql/extensions/sql/tck/JakartaPersitenceEntityTests.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/src/test/java/org/eclipse/jnosql/extensions/sql/tck/TransactionExtension.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/src/test/java/org/eclipse/jnosql/extensions/sql/tck/TransactionExtension.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/src/test/java/org/eclipse/jnosql/extensions/sql/tck/junit/RunOnly.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/src/test/java/org/eclipse/jnosql/extensions/sql/tck/junit/RunOnly.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/src/test/java/org/eclipse/jnosql/extensions/sql/tck/junit/RunOnlyCondition.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/src/test/java/org/eclipse/jnosql/extensions/sql/tck/junit/RunOnlyCondition.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/src/test/resources/META-INF/persistence.xml
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/src/test/resources/META-INF/persistence.xml
@@ -3,10 +3,10 @@
   ~
   ~  Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/pom.xml
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/pom.xml
@@ -3,10 +3,10 @@
   ~
   ~  Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/DefaultSqlTemplate.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/DefaultSqlTemplate.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2026 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/DeleteQueryConverter.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/DeleteQueryConverter.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2026 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/PredicateConverter.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/PredicateConverter.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2026 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/QueryConverterSupport.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/QueryConverterSupport.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2026 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/SelectQueryConverter.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/SelectQueryConverter.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2026 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/SqlDeleteQueryParser.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/SqlDeleteQueryParser.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/SqlEntityMetadata.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/SqlEntityMetadata.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2026 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/SqlIdFieldMetadata.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/SqlIdFieldMetadata.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2026 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/SqlPreparedStatement.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/SqlPreparedStatement.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/SqlQuery.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/SqlQuery.java
@@ -2,10 +2,10 @@
  *   Copyright (c) 2026 Contributors to the Eclipse Foundation.
  *
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/SqlQueryParser.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/SqlQueryParser.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/SqlSelectQuery.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/SqlSelectQuery.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2026 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/SqlSelectQueryParser.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/SqlSelectQueryParser.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/SqlTemplate.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/SqlTemplate.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2026 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/SqlTemplateFactory.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/SqlTemplateFactory.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2026 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/SqlTypedQuery.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/SqlTypedQuery.java
@@ -2,10 +2,10 @@
  *   Copyright (c) 2026 Contributors to the Eclipse Foundation.
  *
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/SqlUpdateQueryParser.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/SqlUpdateQueryParser.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/UpdateQueryConverter.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/UpdateQueryConverter.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2026 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/package-info.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/package-info.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2026 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/repository/NoopRepository.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/repository/NoopRepository.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2026 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/repository/PersistenceRepository.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/repository/PersistenceRepository.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2026 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/repository/RepositoryEntityResolver.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/repository/RepositoryEntityResolver.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2026 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/repository/SqlCountAllOperation.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/repository/SqlCountAllOperation.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/repository/SqlCountByOperation.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/repository/SqlCountByOperation.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/repository/SqlCursorPaginationOperation.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/repository/SqlCursorPaginationOperation.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/repository/SqlDeleteByOperation.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/repository/SqlDeleteByOperation.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/repository/SqlDeleteOperation.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/repository/SqlDeleteOperation.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/repository/SqlExistsByOperation.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/repository/SqlExistsByOperation.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/repository/SqlFindAllOperation.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/repository/SqlFindAllOperation.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/repository/SqlFindByOperation.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/repository/SqlFindByOperation.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/repository/SqlInvocationHandler.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/repository/SqlInvocationHandler.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2026 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/repository/SqlParameterBasedOperation.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/repository/SqlParameterBasedOperation.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/repository/SqlParameterBasedQuery.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/repository/SqlParameterBasedQuery.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/repository/SqlQueryBuilder.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/repository/SqlQueryBuilder.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/repository/SqlQueryOperation.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/repository/SqlQueryOperation.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/repository/SqlRepositoryAdapter.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/repository/SqlRepositoryAdapter.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2026 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/repository/SqlRepositoryOperationProvider.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/repository/SqlRepositoryOperationProvider.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/repository/SqlRepositoryProducer.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/repository/SqlRepositoryProducer.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2026 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/repository/SqlRestrictionConverter.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/repository/SqlRestrictionConverter.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/repository/SqlReturnType.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/repository/SqlReturnType.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/repository/SqlValueConverter.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/repository/SqlValueConverter.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/repository/package-info.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/repository/package-info.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2026 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/repository/spi/AbstractRepositoryPersistenceBean.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/repository/spi/AbstractRepositoryPersistenceBean.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/repository/spi/CustomRepositoryPersistenceBean.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/repository/spi/CustomRepositoryPersistenceBean.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/repository/spi/JakartaPersistenceExtension.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/repository/spi/JakartaPersistenceExtension.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022,2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/repository/spi/RepositoryPersistenceBean.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/repository/spi/RepositoryPersistenceBean.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/CdiUtil.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/CdiUtil.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/JNoSQLJakartaPersistence.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/JNoSQLJakartaPersistence.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/communication/EntityManagerProvider.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/communication/EntityManagerProvider.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/communication/JakartaPersistenceEntitiesMetadata.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/communication/JakartaPersistenceEntitiesMetadata.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2024,2026 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/communication/PersistenceDatabaseManager.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/communication/PersistenceDatabaseManager.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/communication/PersistenceDatabaseManagerProvider.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/communication/PersistenceDatabaseManagerProvider.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2024 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/communication/PersistenceEntityMetadata.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/communication/PersistenceEntityMetadata.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2026 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/communication/PersistenceFieldMetadata.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/communication/PersistenceFieldMetadata.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2026 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/BaseQueryParser.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/BaseQueryParser.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/BaseUpdateQueryParser.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/BaseUpdateQueryParser.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/DataExceptions.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/DataExceptions.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/DeleteQueryParser.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/DeleteQueryParser.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2024,2026 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/EnsureTransaction.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/EnsureTransaction.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/EnsureTransactionInterceptor.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/EnsureTransactionInterceptor.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/PersistenceDocumentTemplate.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/PersistenceDocumentTemplate.java
@@ -2,10 +2,10 @@
  *   Copyright (c) 2024, 2026 Contributors to the Eclipse Foundation.
  *
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/PersistencePreparedStatement.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/PersistencePreparedStatement.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/QLUtil.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/QLUtil.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/QueryModifier.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/QueryModifier.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/SelectQueryParser.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/SelectQueryParser.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2026 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/UpdateQueryParser.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/UpdateQueryParser.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2024,2026 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/cache/MapBasedPersistenceUnitCache.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/cache/MapBasedPersistenceUnitCache.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2024 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/cache/PersistenceUnitCache.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/cache/PersistenceUnitCache.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2024 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/cache/PersistenceUnitCacheProvider.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/cache/PersistenceUnitCacheProvider.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2024 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/core/PersistencePage.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/core/PersistencePage.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2024,2026 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/metadata/JakartaPersistenceClassScanner.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/metadata/JakartaPersistenceClassScanner.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2024 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/parser/OptionalPartsParser.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/parser/OptionalPartsParser.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2025 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/repository/CustomRepositoryPersistenceHandler.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/repository/CustomRepositoryPersistenceHandler.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2024,2026 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/repository/CustomRepositoryPersistenceHandlerBuilder.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/repository/CustomRepositoryPersistenceHandlerBuilder.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/repository/InterceptorInvocationContext.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/repository/InterceptorInvocationContext.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/repository/JakartaPersistenceDefaultRepositoryReturn.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/repository/JakartaPersistenceDefaultRepositoryReturn.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022,2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/repository/JakartaPersistenceDynamicQueryMethodReturn.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/repository/JakartaPersistenceDynamicQueryMethodReturn.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022,2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/repository/JakartaPersistenceDynamicReturnConverter.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/repository/JakartaPersistenceDynamicReturnConverter.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022,2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/repository/JakartaPersistenceParameterBasedQuery.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/repository/JakartaPersistenceParameterBasedQuery.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023,2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/repository/JakartaPersistenceRepositoryProxy.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/repository/JakartaPersistenceRepositoryProxy.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2024,2026 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/repository/MethodInterceptorProxy.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/repository/MethodInterceptorProxy.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2025 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/repository/PersistenceRepositoryInvocationHandler.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/repository/PersistenceRepositoryInvocationHandler.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/repository/PersistenceRepositoryProducer.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/repository/PersistenceRepositoryProducer.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/spi/MethodInterceptor.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/spi/MethodInterceptor.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/resources/META-INF/beans.xml
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/resources/META-INF/beans.xml
@@ -3,10 +3,10 @@
   ~
   ~  Copyright (c) 2024 Contributors to the Eclipse Foundation
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/resources/META-INF/services/jakarta.enterprise.inject.spi.Extension
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/resources/META-INF/services/jakarta.enterprise.inject.spi.Extension
@@ -1,10 +1,10 @@
 #
 #  Copyright (c) 2022 Contributors to the Eclipse Foundation
 #   All rights reserved. This program and the accompanying materials
-#   are made available under the terms of the Eclipse Public License v1.0
+#   are made available under the terms of the Eclipse Public License 2.0
 #   and Apache License v2.0 which accompanies this distribution.
-#   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-#   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+#   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+#   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
 #
 #   You may elect to redistribute this code under either of these licenses.
 #

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/AmbiguousEntityManagerRepository.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/AmbiguousEntityManagerRepository.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/AmbiguousEntityManagerTest.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/AmbiguousEntityManagerTest.java
@@ -1,8 +1,8 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
- *   and Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   are made available under the terms of the Eclipse Public License 2.0
+ *   and Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/CallCountInterceptor.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/CallCountInterceptor.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/CallCounter.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/CallCounter.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/CountCalls.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/CountCalls.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/CountedPersonRepository.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/CountedPersonRepository.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/CustomDefaultEntityManagerRepository.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/CustomDefaultEntityManagerRepository.java
@@ -1,8 +1,8 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
- *   and Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   are made available under the terms of the Eclipse Public License 2.0
+ *   and Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/CustomDefaultEntityManagerTest.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/CustomDefaultEntityManagerTest.java
@@ -1,8 +1,8 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
- *   and Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   are made available under the terms of the Eclipse Public License 2.0
+ *   and Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/CustomEntityManagerAccessRepository.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/CustomEntityManagerAccessRepository.java
@@ -1,8 +1,8 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
- *   and Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   are made available under the terms of the Eclipse Public License 2.0
+ *   and Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/CustomEntityManagerRepository.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/CustomEntityManagerRepository.java
@@ -1,8 +1,8 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
- *   and Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   are made available under the terms of the Eclipse Public License 2.0
+ *   and Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/CustomPersonRepository.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/CustomPersonRepository.java
@@ -1,8 +1,8 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
- *   and Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   are made available under the terms of the Eclipse Public License 2.0
+ *   and Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/CustomQualifiedEntityManagerRepository.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/CustomQualifiedEntityManagerRepository.java
@@ -1,8 +1,8 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
- *   and Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   are made available under the terms of the Eclipse Public License 2.0
+ *   and Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/CustomRepositoryInterceptorTest.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/CustomRepositoryInterceptorTest.java
@@ -1,8 +1,8 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
- *   and Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   are made available under the terms of the Eclipse Public License 2.0
+ *   and Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/EntityManagerAccessRepository.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/EntityManagerAccessRepository.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/EntityManagerAccessTest.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/EntityManagerAccessTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/EntityManagerProducer.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/EntityManagerProducer.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/InterceptorTest.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/InterceptorTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/MethodInterceptedPersonRepository.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/MethodInterceptedPersonRepository.java
@@ -1,8 +1,8 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
- *   and Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   are made available under the terms of the Eclipse Public License 2.0
+ *   and Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/MethodInterceptorTest.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/MethodInterceptorTest.java
@@ -1,8 +1,8 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
- *   and Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   are made available under the terms of the Eclipse Public License 2.0
+ *   and Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/MixedInterceptorPersonRepository.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/MixedInterceptorPersonRepository.java
@@ -1,8 +1,8 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
- *   and Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   are made available under the terms of the Eclipse Public License 2.0
+ *   and Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/MixedInterceptorTest.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/MixedInterceptorTest.java
@@ -1,8 +1,8 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
- *   and Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   are made available under the terms of the Eclipse Public License 2.0
+ *   and Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/PageOutsideTransactionTest.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/PageOutsideTransactionTest.java
@@ -2,9 +2,9 @@
  * Copyright (c) 2026 Contributors to the Eclipse Foundation
  *
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License 2.0
  * and Apache License v2.0 which accompanies this distribution.
- * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
  * and the Apache License v2.0 which accompanies this distribution.
  *
  * You may elect to redistribute this code under either of these licenses.

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/PagePersonRepository.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/PagePersonRepository.java
@@ -2,9 +2,9 @@
  * Copyright (c) 2026 Contributors to the Eclipse Foundation
  *
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License 2.0
  * and Apache License v2.0 which accompanies this distribution.
- * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
  * and the Apache License v2.0 which accompanies this distribution.
  *
  * You may elect to redistribute this code under either of these licenses.

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/Person.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/Person.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/PersonRepository.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/PersonRepository.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/PersonRepositoryTest.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/PersonRepositoryTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/QualifiedEntityManagerRepository.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/QualifiedEntityManagerRepository.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/QualifiedPersonRepository.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/QualifiedPersonRepository.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/QualifierTest.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/QualifierTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/SpecialEntityManager.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/SpecialEntityManager.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/SpecialRepository.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/SpecialRepository.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/TestJakartaPersistenceClassScanner.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/TestJakartaPersistenceClassScanner.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2024 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/TestSupport.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/TestSupport.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2024 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/DefaultSqlTemplateTest.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/DefaultSqlTemplateTest.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2026 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/DeleteQueryConverterTest.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/DeleteQueryConverterTest.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2026 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/SelectQueryConverterTest.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/SelectQueryConverterTest.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2026 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/SqlTemplateFactoryTest.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/SqlTemplateFactoryTest.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2026 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/UpdateQueryConverterTest.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/UpdateQueryConverterTest.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2026 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/model/Computer.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/model/Computer.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/model/ComputerCountByRepository.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/model/ComputerCountByRepository.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/model/ComputerDeleteByRepository.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/model/ComputerDeleteByRepository.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/model/ComputerDeleteRepository.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/model/ComputerDeleteRepository.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/model/ComputerExistByRepository.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/model/ComputerExistByRepository.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/model/ComputerFindByRepository.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/model/ComputerFindByRepository.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/model/ComputerFindRepository.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/model/ComputerFindRepository.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/model/ComputerInsertRepository.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/model/ComputerInsertRepository.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/model/ComputerQueryRepository.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/model/ComputerQueryRepository.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/model/ComputerRepository.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/model/ComputerRepository.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/model/ComputerSaveRepository.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/model/ComputerSaveRepository.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/model/ComputerSummary.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/model/ComputerSummary.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/model/ComputerUpdateRepository.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/model/ComputerUpdateRepository.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/model/Computers.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/model/Computers.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/model/Product.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/model/Product.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/model/_Computer.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/model/_Computer.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/model/_Product.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/model/_Product.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/repository/AbstractTestRepository.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/repository/AbstractTestRepository.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2026 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/repository/CountByOperationRepositoryTest.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/repository/CountByOperationRepositoryTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/repository/DeleteByOperationRepositoryTest.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/repository/DeleteByOperationRepositoryTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/repository/DeleteOperationRepositoryTest.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/repository/DeleteOperationRepositoryTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/repository/ExistByOperationRepositoryTest.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/repository/ExistByOperationRepositoryTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/repository/FindByOperationRepositoryTest.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/repository/FindByOperationRepositoryTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/repository/FindOperationRepositoryTest.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/repository/FindOperationRepositoryTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/repository/InsertOperationRepositoryTest.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/repository/InsertOperationRepositoryTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/repository/QueryOperationRepositoryTest.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/repository/QueryOperationRepositoryTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/repository/RepositoryEntityResolverTest.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/repository/RepositoryEntityResolverTest.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2026 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/repository/SaveOperationRepositoryTest.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/repository/SaveOperationRepositoryTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/repository/SqlRepositoryAdapterTest.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/repository/SqlRepositoryAdapterTest.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2026 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/repository/SqlRepositoryOperationProviderTest.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/repository/SqlRepositoryOperationProviderTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/repository/SqlRepositoryProducerTest.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/repository/SqlRepositoryProducerTest.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2026 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/repository/SqlRestrictionConverterTest.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/repository/SqlRestrictionConverterTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/repository/UpdateOperationRepositoryTest.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/repository/UpdateOperationRepositoryTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/jakartapersistence/mapping/QLUtilTest.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/jakartapersistence/mapping/QLUtilTest.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/jakartapersistence/mapping/parser/OptionalPartsParserTest.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/jakartapersistence/mapping/parser/OptionalPartsParserTest.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2025 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/resources/META-INF/persistence.xml
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/resources/META-INF/persistence.xml
@@ -3,10 +3,10 @@
   ~
   ~  Copyright (c) 2024 Contributors to the Eclipse Foundation
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-scanner/pom.xml
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-scanner/pom.xml
@@ -3,10 +3,10 @@
   ~
   ~  Copyright (c) 2024, 2025 Contributors to the Eclipse Foundation
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-scanner/src/main/java/org/eclipse/jnosql/extensions/sql/reflection/PersistenceClassScannerSingleton.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-scanner/src/main/java/org/eclipse/jnosql/extensions/sql/reflection/PersistenceClassScannerSingleton.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-scanner/src/main/java/org/eclipse/jnosql/extensions/sql/reflection/PersistenceRepositoryFilter.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-scanner/src/main/java/org/eclipse/jnosql/extensions/sql/reflection/PersistenceRepositoryFilter.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023, 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-scanner/src/main/java/org/eclipse/jnosql/extensions/sql/reflection/ReflectionJakartaPersistenceClassScanner.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-scanner/src/main/java/org/eclipse/jnosql/extensions/sql/reflection/ReflectionJakartaPersistenceClassScanner.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-scanner/src/test/java/org/eclipse/jnosql/extensions/sql/reflection/EntityManagerProducer.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-scanner/src/test/java/org/eclipse/jnosql/extensions/sql/reflection/EntityManagerProducer.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-scanner/src/test/java/org/eclipse/jnosql/extensions/sql/reflection/ProviderTest.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-scanner/src/test/java/org/eclipse/jnosql/extensions/sql/reflection/ProviderTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-scanner/src/test/java/org/eclipse/jnosql/extensions/sql/reflection/SupportedRepository.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-scanner/src/test/java/org/eclipse/jnosql/extensions/sql/reflection/SupportedRepository.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-scanner/src/test/java/org/eclipse/jnosql/extensions/sql/reflection/UnsupportedRepository.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-scanner/src/test/java/org/eclipse/jnosql/extensions/sql/reflection/UnsupportedRepository.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-scanner/src/test/resources/META-INF/persistence.xml
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-scanner/src/test/resources/META-INF/persistence.xml
@@ -3,10 +3,10 @@
   ~
   ~  Copyright (c) 2024 Contributors to the Eclipse Foundation
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-jakarta-persistence/pom.xml
+++ b/jnosql-jakarta-persistence/pom.xml
@@ -3,10 +3,10 @@
   ~
   ~  Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-lite/mapping-lite-column-test/pom.xml
+++ b/jnosql-lite/mapping-lite-column-test/pom.xml
@@ -1,10 +1,10 @@
 <!--
   ~  Copyright (c) 2021 Otávio Santana and others
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Actor.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Actor.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/ActorBuilder.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/ActorBuilder.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Address.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Address.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/AppointmentBook.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/AppointmentBook.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Citizen.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Citizen.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/City.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/City.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Contact.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Contact.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/ContactType.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/ContactType.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Director.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Director.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Download.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Download.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Job.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Job.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Money.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Money.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/MoneyConverter.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/MoneyConverter.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Movie.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Movie.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Person.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Person.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/PersonBuilder.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/PersonBuilder.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/PersonCrudRepository.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/PersonCrudRepository.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/PersonRepository.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/PersonRepository.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/UserScope.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/UserScope.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Vendor.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Vendor.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Wine.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Wine.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/WineFactory.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/WineFactory.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Worker.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Worker.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/ZipCode.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/ZipCode.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/autoconverter/BirthdayWishList.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/autoconverter/BirthdayWishList.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/autoconverter/BookWishList.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/autoconverter/BookWishList.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/autoconverter/CarWishList.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/autoconverter/CarWishList.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/autoconverter/ChristmasWishList.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/autoconverter/ChristmasWishList.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/autoconverter/NewYearWishList.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/autoconverter/NewYearWishList.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/autoconverter/TravelWishList.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/autoconverter/TravelWishList.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/autoconverter/WishCollection.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/autoconverter/WishCollection.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/autoconverter/WishCollectionConverter.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/autoconverter/WishCollectionConverter.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/autoconverter/WishCollectionOverwriteConverter.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/autoconverter/WishCollectionOverwriteConverter.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/EmailNotification.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/EmailNotification.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/LargeProject.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/LargeProject.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/Notification.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/Notification.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/NotificationReader.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/NotificationReader.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/Project.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/Project.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/ProjectManager.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/ProjectManager.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/SmallProject.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/SmallProject.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/SmsNotification.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/SmsNotification.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/SocialMediaNotification.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/SocialMediaNotification.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/record/Guest.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/record/Guest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/record/Hotel.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/record/Hotel.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/record/HotelManager.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/record/HotelManager.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/record/Room.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/record/Room.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/ColumnEntityConverterInheritanceTest.java
+++ b/jnosql-lite/mapping-lite-column-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/ColumnEntityConverterInheritanceTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/ColumnEntityConverterRecordTest.java
+++ b/jnosql-lite/mapping-lite-column-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/ColumnEntityConverterRecordTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/ColumnEntityConverterTest.java
+++ b/jnosql-lite/mapping-lite-column-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/ColumnEntityConverterTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/EntityConverterAutoApplyTest.java
+++ b/jnosql-lite/mapping-lite-column-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/EntityConverterAutoApplyTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/PersonCrudRepositoryTest.java
+++ b/jnosql-lite/mapping-lite-column-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/PersonCrudRepositoryTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/PersonRepositoryTest.java
+++ b/jnosql-lite/mapping-lite-column-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/PersonRepositoryTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/pom.xml
+++ b/jnosql-lite/mapping-lite-core-test/pom.xml
@@ -1,10 +1,10 @@
 <!--
   ~  Copyright (c) 2017 Otávio Santana and others
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Actor.java
+++ b/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Actor.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Animal.java
+++ b/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Animal.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2020 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Car.java
+++ b/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Car.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2020 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Computer.java
+++ b/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Computer.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2020 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/ComputerAddress.java
+++ b/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/ComputerAddress.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/CustomAnnotation.java
+++ b/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/CustomAnnotation.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Director.java
+++ b/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Director.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2020 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Money.java
+++ b/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Money.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2020 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/MoneyConverter.java
+++ b/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/MoneyConverter.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2020 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Movie.java
+++ b/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Movie.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2020 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Order.java
+++ b/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Order.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Orders.java
+++ b/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Orders.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2020 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Person.java
+++ b/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Person.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2020 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Product.java
+++ b/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Product.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2020 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/User.java
+++ b/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/User.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Wine.java
+++ b/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Wine.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/WineFactory.java
+++ b/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/WineFactory.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Worker.java
+++ b/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Worker.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/converters/Database.java
+++ b/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/converters/Database.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/converters/NoSQLDatabase.java
+++ b/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/converters/NoSQLDatabase.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/converters/UUIDConverter.java
+++ b/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/converters/UUIDConverter.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/EmailNotification.java
+++ b/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/EmailNotification.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/LargeProject.java
+++ b/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/LargeProject.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/Notification.java
+++ b/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/Notification.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/Project.java
+++ b/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/Project.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/SmallProject.java
+++ b/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/SmallProject.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/SmsNotification.java
+++ b/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/SmsNotification.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/SocialMediaNotification.java
+++ b/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/SocialMediaNotification.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/projection/MovieSummary.java
+++ b/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/projection/MovieSummary.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/projection/PersonSummary.java
+++ b/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/projection/PersonSummary.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/record/Apartment.java
+++ b/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/record/Apartment.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/record/Building.java
+++ b/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/record/Building.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/record/DocumentRecord.java
+++ b/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/record/DocumentRecord.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/record/Guest.java
+++ b/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/record/Guest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/record/Hotel.java
+++ b/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/record/Hotel.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/record/House.java
+++ b/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/record/House.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/record/Room.java
+++ b/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/record/Room.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/repository/ActorRepository.java
+++ b/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/repository/ActorRepository.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/repository/ComputerRepository.java
+++ b/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/repository/ComputerRepository.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/repository/ExampleQuery.java
+++ b/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/repository/ExampleQuery.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/repository/Garage.java
+++ b/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/repository/Garage.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/repository/PersonRepository.java
+++ b/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/repository/PersonRepository.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/ActorTest.java
+++ b/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/ActorTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2020 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/AnimalTest.java
+++ b/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/AnimalTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2020 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/CarTest.java
+++ b/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/CarTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2020 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/ComputerTest.java
+++ b/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/ComputerTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/EntitiesMetadataTest.java
+++ b/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/EntitiesMetadataTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2020 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/MovieTest.java
+++ b/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/MovieTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2020 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/OrderTest.java
+++ b/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/OrderTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2020 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/OrdersTest.java
+++ b/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/OrdersTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/PersonTest.java
+++ b/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/PersonTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2020 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/UserTest.java
+++ b/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/UserTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2020 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/WineTest.java
+++ b/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/WineTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/WorkerTest.java
+++ b/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/WorkerTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2020 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/converters/DatabaseTest.java
+++ b/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/converters/DatabaseTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/converters/NoSQLDatabaseTest.java
+++ b/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/converters/NoSQLDatabaseTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/EmailNotificationTest.java
+++ b/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/EmailNotificationTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/LargeProjectTest.java
+++ b/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/LargeProjectTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/NotificationTest.java
+++ b/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/NotificationTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/ProjectTest.java
+++ b/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/ProjectTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/SMSNotificationTest.java
+++ b/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/SMSNotificationTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/SmallProjectTest.java
+++ b/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/SmallProjectTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/SocialMediaNotificationTest.java
+++ b/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/SocialMediaNotificationTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/projection/MovieSummaryTest.java
+++ b/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/projection/MovieSummaryTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/projection/PersonSummaryTest.java
+++ b/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/projection/PersonSummaryTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/record/ApartmentTest.java
+++ b/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/record/ApartmentTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/record/BuildingTest.java
+++ b/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/record/BuildingTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/record/DocumentRecordTest.java
+++ b/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/record/DocumentRecordTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/record/GuestTest.java
+++ b/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/record/GuestTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/record/HotelTest.java
+++ b/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/record/HotelTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/record/RoomTest.java
+++ b/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/record/RoomTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/metadata/CarLifecycleEventObserver.java
+++ b/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/metadata/CarLifecycleEventObserver.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/metadata/LiteEntitiesMetadataTest.java
+++ b/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/metadata/LiteEntitiesMetadataTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/metadata/LiteLifecycleEventHandlerTest.java
+++ b/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/metadata/LiteLifecycleEventHandlerTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/metadata/LiteRepositoriesMetadataTest.java
+++ b/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/metadata/LiteRepositoriesMetadataTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/metadata/ObservedLifecycleEvent.java
+++ b/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/metadata/ObservedLifecycleEvent.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/metadata/ObservedLifecycleEventType.java
+++ b/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/metadata/ObservedLifecycleEventType.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/metadata/RepositoryMethodLookupTest.java
+++ b/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/metadata/RepositoryMethodLookupTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/pom.xml
+++ b/jnosql-lite/mapping-lite-document-test/pom.xml
@@ -1,10 +1,10 @@
 <!--
   ~  Copyright (c) 2021 Otávio Santana and others
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Actor.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Actor.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/ActorBuilder.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/ActorBuilder.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Address.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Address.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/AppointmentBook.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/AppointmentBook.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Citizen.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Citizen.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/City.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/City.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Contact.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Contact.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/ContactType.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/ContactType.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Director.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Director.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Download.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Download.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Job.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Job.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Money.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Money.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/MoneyConverter.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/MoneyConverter.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Movie.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Movie.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Person.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Person.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/PersonBuilder.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/PersonBuilder.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/PersonCrudRepository.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/PersonCrudRepository.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/PersonRepository.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/PersonRepository.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/UserScope.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/UserScope.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Vendor.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Vendor.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Wine.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Wine.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/WineFactory.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/WineFactory.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Worker.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Worker.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/ZipCode.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/ZipCode.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/autoconverter/BirthdayWishList.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/autoconverter/BirthdayWishList.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/autoconverter/BookWishList.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/autoconverter/BookWishList.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/autoconverter/CarWishList.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/autoconverter/CarWishList.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/autoconverter/ChristmasWishList.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/autoconverter/ChristmasWishList.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/autoconverter/NewYearWishList.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/autoconverter/NewYearWishList.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/autoconverter/TravelWishList.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/autoconverter/TravelWishList.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/autoconverter/WishCollection.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/autoconverter/WishCollection.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/autoconverter/WishCollectionConverter.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/autoconverter/WishCollectionConverter.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/autoconverter/WishCollectionOverwriteConverter.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/autoconverter/WishCollectionOverwriteConverter.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/EmailNotification.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/EmailNotification.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/LargeProject.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/LargeProject.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/Notification.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/Notification.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/NotificationReader.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/NotificationReader.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/Project.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/Project.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/ProjectManager.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/ProjectManager.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/SmallProject.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/SmallProject.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/SmsNotification.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/SmsNotification.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/SocialMediaNotification.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/SocialMediaNotification.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/record/Guest.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/record/Guest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/record/Hotel.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/record/Hotel.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/record/HotelManager.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/record/HotelManager.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/record/Room.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/record/Room.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/DocumentEntityConverterInheritanceTest.java
+++ b/jnosql-lite/mapping-lite-document-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/DocumentEntityConverterInheritanceTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/DocumentEntityConverterRecordTest.java
+++ b/jnosql-lite/mapping-lite-document-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/DocumentEntityConverterRecordTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/DocumentEntityConverterTest.java
+++ b/jnosql-lite/mapping-lite-document-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/DocumentEntityConverterTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/EntityConverterAutoApplyTest.java
+++ b/jnosql-lite/mapping-lite-document-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/EntityConverterAutoApplyTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/PersonCrudRepositoryTest.java
+++ b/jnosql-lite/mapping-lite-document-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/PersonCrudRepositoryTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/PersonRepositoryTest.java
+++ b/jnosql-lite/mapping-lite-document-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/PersonRepositoryTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/pom.xml
+++ b/jnosql-lite/mapping-lite-graph-test/pom.xml
@@ -1,10 +1,10 @@
 <!--
   ~  Copyright (c) 2021 Otávio Santana and others
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Actor.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Actor.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/ActorBuilder.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/ActorBuilder.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Address.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Address.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/AppointmentBook.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/AppointmentBook.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Citizen.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Citizen.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/City.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/City.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Contact.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Contact.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/ContactType.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/ContactType.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Director.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Director.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Download.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Download.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Job.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Job.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Money.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Money.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/MoneyConverter.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/MoneyConverter.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Movie.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Movie.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Person.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Person.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/PersonBuilder.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/PersonBuilder.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/PersonCrudRepository.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/PersonCrudRepository.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/PersonRepository.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/PersonRepository.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/UserScope.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/UserScope.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Vendor.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Vendor.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Wine.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Wine.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/WineFactory.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/WineFactory.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Worker.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Worker.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/ZipCode.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/ZipCode.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/autoconverter/BirthdayWishList.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/autoconverter/BirthdayWishList.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/autoconverter/BookWishList.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/autoconverter/BookWishList.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/autoconverter/CarWishList.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/autoconverter/CarWishList.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/autoconverter/ChristmasWishList.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/autoconverter/ChristmasWishList.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/autoconverter/NewYearWishList.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/autoconverter/NewYearWishList.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/autoconverter/TravelWishList.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/autoconverter/TravelWishList.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/autoconverter/WishCollection.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/autoconverter/WishCollection.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/autoconverter/WishCollectionConverter.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/autoconverter/WishCollectionConverter.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/autoconverter/WishCollectionOverwriteConverter.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/autoconverter/WishCollectionOverwriteConverter.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/EmailNotification.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/EmailNotification.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/LargeProject.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/LargeProject.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/Notification.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/Notification.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/NotificationReader.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/NotificationReader.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/Project.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/Project.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/ProjectManager.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/ProjectManager.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/SmallProject.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/SmallProject.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/SmsNotification.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/SmsNotification.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/SocialMediaNotification.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/SocialMediaNotification.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/record/Guest.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/record/Guest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/record/Hotel.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/record/Hotel.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/record/HotelManager.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/record/HotelManager.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/record/Room.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/record/Room.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/EntityConverterAutoApplyTest.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/EntityConverterAutoApplyTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/GraphEntityConverterInheritanceTest.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/GraphEntityConverterInheritanceTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/GraphEntityConverterRecordTest.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/GraphEntityConverterRecordTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/GraphEntityConverterTest.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/GraphEntityConverterTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/PersonCrudRepositoryTest.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/PersonCrudRepositoryTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/PersonRepositoryTest.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/PersonRepositoryTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-key-value-test/pom.xml
+++ b/jnosql-lite/mapping-lite-key-value-test/pom.xml
@@ -1,10 +1,10 @@
 <!--
   ~  Copyright (c) 2021 Otávio Santana and others
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-lite/mapping-lite-key-value-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Car.java
+++ b/jnosql-lite/mapping-lite-key-value-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Car.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-key-value-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Job.java
+++ b/jnosql-lite/mapping-lite-key-value-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Job.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-key-value-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Money.java
+++ b/jnosql-lite/mapping-lite-key-value-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Money.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-key-value-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/MoneyConverter.java
+++ b/jnosql-lite/mapping-lite-key-value-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/MoneyConverter.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-key-value-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Person.java
+++ b/jnosql-lite/mapping-lite-key-value-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Person.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-key-value-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/PersonBuilder.java
+++ b/jnosql-lite/mapping-lite-key-value-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/PersonBuilder.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-key-value-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/PersonRepository.java
+++ b/jnosql-lite/mapping-lite-key-value-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/PersonRepository.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-key-value-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Plate.java
+++ b/jnosql-lite/mapping-lite-key-value-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Plate.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-key-value-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/PlateConverter.java
+++ b/jnosql-lite/mapping-lite-key-value-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/PlateConverter.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-key-value-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/User.java
+++ b/jnosql-lite/mapping-lite-key-value-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/User.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-key-value-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/UserCrudRepository.java
+++ b/jnosql-lite/mapping-lite-key-value-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/UserCrudRepository.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-key-value-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/UserRepository.java
+++ b/jnosql-lite/mapping-lite-key-value-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/UserRepository.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-key-value-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Worker.java
+++ b/jnosql-lite/mapping-lite-key-value-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Worker.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-key-value-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/KeyValueEntityConverterTest.java
+++ b/jnosql-lite/mapping-lite-key-value-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/KeyValueEntityConverterTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-key-value-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/UserCrudRepositoryLiteKeyValueTest.java
+++ b/jnosql-lite/mapping-lite-key-value-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/UserCrudRepositoryLiteKeyValueTest.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-key-value-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/UserRepositoryLiteKeyValueTest.java
+++ b/jnosql-lite/mapping-lite-key-value-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/UserRepositoryLiteKeyValueTest.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/pom.xml
+++ b/jnosql-lite/mapping-lite-processor/pom.xml
@@ -1,10 +1,10 @@
 <!--
   ~  Copyright (c) 2017 Otávio Santana and others
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/ConstructorMetamodel.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/ConstructorMetamodel.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/MappingIntrospector.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/MappingIntrospector.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2020 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/MappingProcessor.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/MappingProcessor.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2020 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/ParameterResult.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/ParameterResult.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/ProcessorUtil.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/ProcessorUtil.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2020 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/RepositoryMetadataProcessor.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/RepositoryMetadataProcessor.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/ValidationException.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/ValidationException.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2020 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/constructor/ConstructorMetadataModel.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/constructor/ConstructorMetadataModel.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  */

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/constructor/ConstructorParameter.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/constructor/ConstructorParameter.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  */

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/constructor/ParameterAnalyzer.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/constructor/ParameterAnalyzer.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2020 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/constructor/ParameterModel.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/constructor/ParameterModel.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2020 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/constructor/package-info.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/constructor/package-info.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  */

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/converter/AutoApplyConverterModel.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/converter/AutoApplyConverterModel.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/converter/AutoApplyConverterProcessor.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/converter/AutoApplyConverterProcessor.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/converter/package-info.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/converter/package-info.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  */

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/entity/EntitiesMetadataModel.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/entity/EntitiesMetadataModel.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2020 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/entity/EntityConstructorIntrospector.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/entity/EntityConstructorIntrospector.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/entity/EntityFieldCollector.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/entity/EntityFieldCollector.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/entity/EntityMappingIntrospector.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/entity/EntityMappingIntrospector.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/entity/EntityModel.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/entity/EntityModel.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2020 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/entity/EntityModelIntrospector.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/entity/EntityModelIntrospector.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/entity/EntitySourceGenerator.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/entity/EntitySourceGenerator.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/entity/field/FieldAccessorIntrospector.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/entity/field/FieldAccessorIntrospector.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/entity/field/FieldAnalyzer.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/entity/field/FieldAnalyzer.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2020 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/entity/field/FieldAnnotationIntrospector.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/entity/field/FieldAnnotationIntrospector.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/entity/field/FieldModel.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/entity/field/FieldModel.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2020 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/entity/field/FieldSourceGenerator.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/entity/field/FieldSourceGenerator.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/entity/field/FieldTypeIntrospector.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/entity/field/FieldTypeIntrospector.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/entity/field/ValueAnnotationModel.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/entity/field/ValueAnnotationModel.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/entity/field/package-info.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/entity/field/package-info.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  */

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/entity/package-info.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/entity/package-info.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  */

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/events/LifecycleEventTypesIntrospect.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/events/LifecycleEventTypesIntrospect.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/events/LifecycleEventTypesModel.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/events/LifecycleEventTypesModel.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/events/LifecycleEventTypesProcessor.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/events/LifecycleEventTypesProcessor.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/events/package-info.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/events/package-info.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  */

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/metadata/AutoApplyConverterMetadata.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/metadata/AutoApplyConverterMetadata.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/metadata/AutoApplyConverters.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/metadata/AutoApplyConverters.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/metadata/CollectionSupplierProvider.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/metadata/CollectionSupplierProvider.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2020 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/metadata/DefaultConstructorMetadata.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/metadata/DefaultConstructorMetadata.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/metadata/DequeSupplier.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/metadata/DequeSupplier.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2020 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/metadata/JNoSQLRepositoryProcessor.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/metadata/JNoSQLRepositoryProcessor.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/metadata/LifecycleEventTypes.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/metadata/LifecycleEventTypes.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/metadata/ListSupplier.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/metadata/ListSupplier.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2020 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/metadata/LiteClassConverter.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/metadata/LiteClassConverter.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/metadata/LiteClassScanner.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/metadata/LiteClassScanner.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/metadata/LiteConstructorBuilder.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/metadata/LiteConstructorBuilder.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/metadata/LiteConstructorBuilderSupplier.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/metadata/LiteConstructorBuilderSupplier.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/metadata/LiteConstructorInvoker.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/metadata/LiteConstructorInvoker.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/metadata/LiteConstructorMetadata.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/metadata/LiteConstructorMetadata.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/metadata/LiteEntityMetadata.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/metadata/LiteEntityMetadata.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/metadata/LiteLifecycleEventHandler.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/metadata/LiteLifecycleEventHandler.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/metadata/LiteProjectorConstructorBuilder.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/metadata/LiteProjectorConstructorBuilder.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/metadata/LiteProjectorConstructorBuilderSupplier.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/metadata/LiteProjectorConstructorBuilderSupplier.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/metadata/LiteProjectorConstructorMetadata.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/metadata/LiteProjectorConstructorMetadata.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/metadata/RepositoryMethodLookup.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/metadata/RepositoryMethodLookup.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Otavio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/metadata/SetSupplier.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/metadata/SetSupplier.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2020 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/metadata/TreeSetSupplier.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/metadata/TreeSetSupplier.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2020 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/metadata/package-info.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/metadata/package-info.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  */

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/package-info.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/package-info.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  */

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/processing/BaseMappingModel.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/processing/BaseMappingModel.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2020 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/processing/CollectionUtil.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/processing/CollectionUtil.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/processing/ElementPredicates.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/processing/ElementPredicates.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/processing/MappingCategory.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/processing/MappingCategory.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/processing/MappingResult.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/processing/MappingResult.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/processing/MetadataAppender.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/processing/MetadataAppender.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2020 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/processing/ProcessorUtils.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/processing/ProcessorUtils.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  */

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/processing/ProcessorValidationException.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/processing/ProcessorValidationException.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  */

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/processing/package-info.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/processing/package-info.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  */

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/projection/ProjectionMappingIntrospector.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/projection/ProjectionMappingIntrospector.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/projection/ProjectionModel.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/projection/ProjectionModel.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/projection/ProjectorParameterAnalyzer.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/projection/ProjectorParameterAnalyzer.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2020 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/projection/package-info.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/projection/package-info.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  */

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/AnnotationOperationMethodBuilder.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/AnnotationOperationMethodBuilder.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/AnnotationQueryRepositoryReturnType.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/AnnotationQueryRepositoryReturnType.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2021 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/DatabaseSupport.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/DatabaseSupport.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/KeyValueMethodBuilder.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/KeyValueMethodBuilder.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2021 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/KeyValueRepositoryMetadata.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/KeyValueRepositoryMetadata.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2021 Otavio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/MethodGenerator.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/MethodGenerator.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2021 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/MethodMetadata.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/MethodMetadata.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2021 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/MethodMetadataOperationType.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/MethodMetadataOperationType.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/MethodQueryRepositoryReturnType.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/MethodQueryRepositoryReturnType.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2021 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/MethodSignatureKeyConstant.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/MethodSignatureKeyConstant.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/MethodSignatureKeyExtractor.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/MethodSignatureKeyExtractor.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/Parameter.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/Parameter.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2021 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/RepositoryAnalyzer.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/RepositoryAnalyzer.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2021 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/RepositoryElement.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/RepositoryElement.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2021 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/RepositoryMetadata.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/RepositoryMetadata.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2021 Otavio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/RepositoryProcessor.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/RepositoryProcessor.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/RepositoryTemplateType.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/RepositoryTemplateType.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2021 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/RepositoryUtil.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/RepositoryUtil.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2021 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/SemiStructureRepositoryMetadata.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/SemiStructureRepositoryMetadata.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2021 Otavio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/metadata/MethodTypeUtils.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/metadata/MethodTypeUtils.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/metadata/RepositoriesMetadataModel.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/metadata/RepositoriesMetadataModel.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/metadata/RepositoryIntrospector.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/metadata/RepositoryIntrospector.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/metadata/RepositoryMetaModel.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/metadata/RepositoryMetaModel.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/metadata/RepositoryMethodAnnotationCollector.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/metadata/RepositoryMethodAnnotationCollector.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/metadata/RepositoryMethodAnnotationIntrospector.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/metadata/RepositoryMethodAnnotationIntrospector.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/metadata/RepositoryMethodAnnotationModel.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/metadata/RepositoryMethodAnnotationModel.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/metadata/RepositoryMethodIntrospector.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/metadata/RepositoryMethodIntrospector.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/metadata/RepositoryMethodModel.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/metadata/RepositoryMethodModel.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/metadata/RepositoryMethodParamModel.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/metadata/RepositoryMethodParamModel.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/metadata/RepositoryMethodParameterCollector.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/metadata/RepositoryMethodParameterCollector.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/metadata/RepositoryMethodParameterIntrospector.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/metadata/RepositoryMethodParameterIntrospector.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/metadata/RepositoryMethodQueryIntrospector.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/metadata/RepositoryMethodQueryIntrospector.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/metadata/RepositoryMethodReturnTypeIntrospector.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/metadata/RepositoryMethodReturnTypeIntrospector.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/metadata/RepositoryMethodSourceGenerator.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/metadata/RepositoryMethodSourceGenerator.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/metadata/package-info.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/metadata/package-info.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  */

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/package-info.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/package-info.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  */

--- a/jnosql-lite/mapping-lite-processor/src/main/resources/auto_apply_converter.mustache
+++ b/jnosql-lite/mapping-lite-processor/src/main/resources/auto_apply_converter.mustache
@@ -1,10 +1,10 @@
 /*
 *   Copyright (c) {{currentYear}} Otávio Santana and others
 *   All rights reserved. This program and the accompanying materials
-*   are made available under the terms of the Eclipse Public License v1.0
+*   are made available under the terms of the Eclipse Public License 2.0
 *   and Apache License v2.0 which accompanies this distribution.
-*   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-*   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+*   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+*   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
 *
 *   You may elect to redistribute this code under either of these licenses.
 *

--- a/jnosql-lite/mapping-lite-processor/src/main/resources/constructor_metadata.mustache
+++ b/jnosql-lite/mapping-lite-processor/src/main/resources/constructor_metadata.mustache
@@ -1,10 +1,10 @@
 /*
 *   Copyright (c) {{currentYear}} Otávio Santana and others
 *   All rights reserved. This program and the accompanying materials
-*   are made available under the terms of the Eclipse Public License v1.0
+*   are made available under the terms of the Eclipse Public License 2.0
 *   and Apache License v2.0 which accompanies this distribution.
-*   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-*   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+*   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+*   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
 *
 *   You may elect to redistribute this code under either of these licenses.
 *

--- a/jnosql-lite/mapping-lite-processor/src/main/resources/entities_metadata.mustache
+++ b/jnosql-lite/mapping-lite-processor/src/main/resources/entities_metadata.mustache
@@ -1,10 +1,10 @@
 /*
 *   Copyright (c) {{currentYear}} Otávio Santana and others
 *   All rights reserved. This program and the accompanying materials
-*   are made available under the terms of the Eclipse Public License v1.0
+*   are made available under the terms of the Eclipse Public License 2.0
 *   and Apache License v2.0 which accompanies this distribution.
-*   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-*   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+*   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+*   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
 *
 *   You may elect to redistribute this code under either of these licenses.
 *

--- a/jnosql-lite/mapping-lite-processor/src/main/resources/entity_metadata.mustache
+++ b/jnosql-lite/mapping-lite-processor/src/main/resources/entity_metadata.mustache
@@ -1,10 +1,10 @@
 /*
 *   Copyright (c) {{currentYear}} Otávio Santana and others
 *   All rights reserved. This program and the accompanying materials
-*   are made available under the terms of the Eclipse Public License v1.0
+*   are made available under the terms of the Eclipse Public License 2.0
 *   and Apache License v2.0 which accompanies this distribution.
-*   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-*   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+*   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+*   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
 *
 *   You may elect to redistribute this code under either of these licenses.
 *

--- a/jnosql-lite/mapping-lite-processor/src/main/resources/field_array_metadata.mustache
+++ b/jnosql-lite/mapping-lite-processor/src/main/resources/field_array_metadata.mustache
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) {{currentYear}} Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/resources/field_collection_metadata.mustache
+++ b/jnosql-lite/mapping-lite-processor/src/main/resources/field_collection_metadata.mustache
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) {{currentYear}} Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/resources/field_map_metadata.mustache
+++ b/jnosql-lite/mapping-lite-processor/src/main/resources/field_map_metadata.mustache
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) {{currentYear}} Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/resources/field_metadata.mustache
+++ b/jnosql-lite/mapping-lite-processor/src/main/resources/field_metadata.mustache
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) {{currentYear}} Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/resources/lite_lifecycle_event.mustache
+++ b/jnosql-lite/mapping-lite-processor/src/main/resources/lite_lifecycle_event.mustache
@@ -1,10 +1,10 @@
 /*
 *   Copyright (c) {{currentYear}} Otávio Santana and others
 *   All rights reserved. This program and the accompanying materials
-*   are made available under the terms of the Eclipse Public License v1.0
+*   are made available under the terms of the Eclipse Public License 2.0
 *   and Apache License v2.0 which accompanies this distribution.
-*   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-*   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+*   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+*   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
 *
 *   You may elect to redistribute this code under either of these licenses.
 *

--- a/jnosql-lite/mapping-lite-processor/src/main/resources/parameter_array_metadata.mustache
+++ b/jnosql-lite/mapping-lite-processor/src/main/resources/parameter_array_metadata.mustache
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) {{currentYear}} Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/resources/parameter_collection_metadata.mustache
+++ b/jnosql-lite/mapping-lite-processor/src/main/resources/parameter_collection_metadata.mustache
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) {{currentYear}} Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/resources/parameter_map_metadata.mustache
+++ b/jnosql-lite/mapping-lite-processor/src/main/resources/parameter_map_metadata.mustache
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) {{currentYear}} Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/resources/parameter_metadata.mustache
+++ b/jnosql-lite/mapping-lite-processor/src/main/resources/parameter_metadata.mustache
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) {{currentYear}} Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/resources/projector_constructor_metadata.mustache
+++ b/jnosql-lite/mapping-lite-processor/src/main/resources/projector_constructor_metadata.mustache
@@ -1,10 +1,10 @@
 /*
 *   Copyright (c) {{currentYear}} Otávio Santana and others
 *   All rights reserved. This program and the accompanying materials
-*   are made available under the terms of the Eclipse Public License v1.0
+*   are made available under the terms of the Eclipse Public License 2.0
 *   and Apache License v2.0 which accompanies this distribution.
-*   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-*   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+*   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+*   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
 *
 *   You may elect to redistribute this code under either of these licenses.
 *

--- a/jnosql-lite/mapping-lite-processor/src/main/resources/projector_metadata.mustache
+++ b/jnosql-lite/mapping-lite-processor/src/main/resources/projector_metadata.mustache
@@ -1,10 +1,10 @@
 /*
 *   Copyright (c) {{currentYear}} Otávio Santana and others
 *   All rights reserved. This program and the accompanying materials
-*   are made available under the terms of the Eclipse Public License v1.0
+*   are made available under the terms of the Eclipse Public License 2.0
 *   and Apache License v2.0 which accompanies this distribution.
-*   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-*   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+*   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+*   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
 *
 *   You may elect to redistribute this code under either of these licenses.
 *

--- a/jnosql-lite/mapping-lite-processor/src/main/resources/projector_parameter_metadata.mustache
+++ b/jnosql-lite/mapping-lite-processor/src/main/resources/projector_parameter_metadata.mustache
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) {{currentYear}} Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/resources/repositories_metadata.mustache
+++ b/jnosql-lite/mapping-lite-processor/src/main/resources/repositories_metadata.mustache
@@ -1,10 +1,10 @@
 /*
 *   Copyright (c) {{currentYear}} Otávio Santana and others
 *   All rights reserved. This program and the accompanying materials
-*   are made available under the terms of the Eclipse Public License v1.0
+*   are made available under the terms of the Eclipse Public License 2.0
 *   and Apache License v2.0 which accompanies this distribution.
-*   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-*   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+*   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+*   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
 *
 *   You may elect to redistribute this code under either of these licenses.
 *

--- a/jnosql-lite/mapping-lite-processor/src/main/resources/repository_key-value.mustache
+++ b/jnosql-lite/mapping-lite-processor/src/main/resources/repository_key-value.mustache
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) {{currentYear}} Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/resources/repository_metadata.mustache
+++ b/jnosql-lite/mapping-lite-processor/src/main/resources/repository_metadata.mustache
@@ -1,10 +1,10 @@
 /*
 *   Copyright (c) {{currentYear}} Otávio Santana and others
 *   All rights reserved. This program and the accompanying materials
-*   are made available under the terms of the Eclipse Public License v1.0
+*   are made available under the terms of the Eclipse Public License 2.0
 *   and Apache License v2.0 which accompanies this distribution.
-*   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-*   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+*   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+*   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
 *
 *   You may elect to redistribute this code under either of these licenses.
 *

--- a/jnosql-lite/mapping-lite-processor/src/main/resources/repository_method_annotations_metadata.mustache
+++ b/jnosql-lite/mapping-lite-processor/src/main/resources/repository_method_annotations_metadata.mustache
@@ -1,10 +1,10 @@
 /*
 *   Copyright (c) {{currentYear}} Otávio Santana and others
 *   All rights reserved. This program and the accompanying materials
-*   are made available under the terms of the Eclipse Public License v1.0
+*   are made available under the terms of the Eclipse Public License 2.0
 *   and Apache License v2.0 which accompanies this distribution.
-*   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-*   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+*   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+*   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
 *
 *   You may elect to redistribute this code under either of these licenses.
 *

--- a/jnosql-lite/mapping-lite-processor/src/main/resources/repository_method_metadata.mustache
+++ b/jnosql-lite/mapping-lite-processor/src/main/resources/repository_method_metadata.mustache
@@ -1,10 +1,10 @@
 /*
 *   Copyright (c) {{currentYear}} Otávio Santana and others
 *   All rights reserved. This program and the accompanying materials
-*   are made available under the terms of the Eclipse Public License v1.0
+*   are made available under the terms of the Eclipse Public License 2.0
 *   and Apache License v2.0 which accompanies this distribution.
-*   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-*   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+*   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+*   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
 *
 *   You may elect to redistribute this code under either of these licenses.
 *

--- a/jnosql-lite/mapping-lite-processor/src/main/resources/repository_method_params_metadata.mustache
+++ b/jnosql-lite/mapping-lite-processor/src/main/resources/repository_method_params_metadata.mustache
@@ -1,10 +1,10 @@
 /*
 *   Copyright (c) {{currentYear}} Otávio Santana and others
 *   All rights reserved. This program and the accompanying materials
-*   are made available under the terms of the Eclipse Public License v1.0
+*   are made available under the terms of the Eclipse Public License 2.0
 *   and Apache License v2.0 which accompanies this distribution.
-*   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-*   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+*   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+*   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
 *
 *   You may elect to redistribute this code under either of these licenses.
 *

--- a/jnosql-lite/mapping-lite-processor/src/main/resources/repository_semi_structure.mustache
+++ b/jnosql-lite/mapping-lite-processor/src/main/resources/repository_semi_structure.mustache
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) {{currentYear}} Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/test/java/org/eclipse/jnosql/lite/mapping/CollectionUtilTest.java
+++ b/jnosql-lite/mapping-lite-processor/src/test/java/org/eclipse/jnosql/lite/mapping/CollectionUtilTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/test/java/org/eclipse/jnosql/lite/mapping/LiteClassConverterTest.java
+++ b/jnosql-lite/mapping-lite-processor/src/test/java/org/eclipse/jnosql/lite/mapping/LiteClassConverterTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/test/java/org/eclipse/jnosql/lite/mapping/LiteClassScannerTest.java
+++ b/jnosql-lite/mapping-lite-processor/src/test/java/org/eclipse/jnosql/lite/mapping/LiteClassScannerTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/test/java/org/eclipse/jnosql/lite/mapping/LiteConstructorBuilderSupplierTest.java
+++ b/jnosql-lite/mapping-lite-processor/src/test/java/org/eclipse/jnosql/lite/mapping/LiteConstructorBuilderSupplierTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/test/java/org/eclipse/jnosql/lite/mapping/ProcessorUtilTest.java
+++ b/jnosql-lite/mapping-lite-processor/src/test/java/org/eclipse/jnosql/lite/mapping/ProcessorUtilTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/test/java/org/eclipse/jnosql/lite/mapping/metadata/AutoApplyConvertersTest.java
+++ b/jnosql-lite/mapping-lite-processor/src/test/java/org/eclipse/jnosql/lite/mapping/metadata/AutoApplyConvertersTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/test/java/org/eclipse/jnosql/lite/mapping/metadata/CollectionSupplierProviderTest.java
+++ b/jnosql-lite/mapping-lite-processor/src/test/java/org/eclipse/jnosql/lite/mapping/metadata/CollectionSupplierProviderTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/test/java/org/eclipse/jnosql/lite/mapping/metadata/DefaultConstructorMetadataTest.java
+++ b/jnosql-lite/mapping-lite-processor/src/test/java/org/eclipse/jnosql/lite/mapping/metadata/DefaultConstructorMetadataTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/test/java/org/eclipse/jnosql/lite/mapping/metadata/JNoSQLRepositoryProcessorTest.java
+++ b/jnosql-lite/mapping-lite-processor/src/test/java/org/eclipse/jnosql/lite/mapping/metadata/JNoSQLRepositoryProcessorTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/test/java/org/eclipse/jnosql/lite/mapping/metadata/LiteConstructorBuilderTest.java
+++ b/jnosql-lite/mapping-lite-processor/src/test/java/org/eclipse/jnosql/lite/mapping/metadata/LiteConstructorBuilderTest.java
@@ -1,9 +1,9 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and the Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
  *   and the Apache License v2.0 which accompanies this distribution.
  *
  *   You may elect to redistribute this code under either of these licenses.

--- a/jnosql-lite/mapping-lite-processor/src/test/java/org/eclipse/jnosql/lite/mapping/metadata/LiteLifecycleEventHandlerTest.java
+++ b/jnosql-lite/mapping-lite-processor/src/test/java/org/eclipse/jnosql/lite/mapping/metadata/LiteLifecycleEventHandlerTest.java
@@ -1,9 +1,9 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and the Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
  *   and the Apache License v2.0 which accompanies this distribution.
  *
  *   You may elect to redistribute this code under either of these licenses.

--- a/jnosql-lite/mapping-lite-processor/src/test/java/org/eclipse/jnosql/lite/mapping/metadata/LiteProjectorConstructorBuilderSupplierTest.java
+++ b/jnosql-lite/mapping-lite-processor/src/test/java/org/eclipse/jnosql/lite/mapping/metadata/LiteProjectorConstructorBuilderSupplierTest.java
@@ -1,9 +1,9 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
  *   and the Apache License v2.0 which accompanies this distribution.
  *
  *   You may elect to redistribute this code under either of these licenses.

--- a/jnosql-lite/mapping-lite-processor/src/test/java/org/eclipse/jnosql/lite/mapping/metadata/LiteProjectorConstructorBuilderTest.java
+++ b/jnosql-lite/mapping-lite-processor/src/test/java/org/eclipse/jnosql/lite/mapping/metadata/LiteProjectorConstructorBuilderTest.java
@@ -1,9 +1,9 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and the Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
  *   and the Apache License v2.0 which accompanies this distribution.
  *
  *   You may elect to redistribute this code under either of these licenses.

--- a/jnosql-lite/mapping-lite-processor/src/test/java/org/eclipse/jnosql/lite/mapping/metadata/TestAutoApplyConverterMetadata.java
+++ b/jnosql-lite/mapping-lite-processor/src/test/java/org/eclipse/jnosql/lite/mapping/metadata/TestAutoApplyConverterMetadata.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/test/java/org/eclipse/jnosql/lite/mapping/metadata/TestLifecycleEventTypes.java
+++ b/jnosql-lite/mapping-lite-processor/src/test/java/org/eclipse/jnosql/lite/mapping/metadata/TestLifecycleEventTypes.java
@@ -1,9 +1,9 @@
 /*
  *  Copyright (c) 2026 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and the Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
  *   and the Apache License v2.0 which accompanies this distribution.
  *
  *   You may elect to redistribute this code under either of these licenses.

--- a/jnosql-lite/pom.xml
+++ b/jnosql-lite/pom.xml
@@ -3,10 +3,10 @@
   ~  Copyright (c) 2026 Contributors to the Eclipse Foundation
   ~  Copyright (c) 2017 Otávio Santana and others
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-mapping-validation/pom.xml
+++ b/jnosql-mapping-validation/pom.xml
@@ -1,10 +1,10 @@
 <!--
   ~  Copyright (c) 2022 Contributors to the Eclipse Foundation
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-mapping-validation/src/main/java/org/eclipse/jnosql/mapping/validation/EntityObserver.java
+++ b/jnosql-mapping-validation/src/main/java/org/eclipse/jnosql/mapping/validation/EntityObserver.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-mapping-validation/src/main/java/org/eclipse/jnosql/mapping/validation/MappingValidator.java
+++ b/jnosql-mapping-validation/src/main/java/org/eclipse/jnosql/mapping/validation/MappingValidator.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-mapping-validation/src/main/resources/META-INF/beans.xml
+++ b/jnosql-mapping-validation/src/main/resources/META-INF/beans.xml
@@ -1,10 +1,10 @@
 <!--
   ~  Copyright (c) 2022 Contributors to the Eclipse Foundation
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-mapping-validation/src/test/resources/META-INF/beans.xml
+++ b/jnosql-mapping-validation/src/test/resources/META-INF/beans.xml
@@ -1,10 +1,10 @@
 <!--
   ~  Copyright (c) 2022 Contributors to the Eclipse Foundation
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-nosql-tck-runner/pom.xml
+++ b/jnosql-nosql-tck-runner/pom.xml
@@ -3,10 +3,10 @@
   ~
   ~  Copyright (c) 2024 Contributors to the Eclipse Foundation
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-nosql-tck-runner/src/test/java/org/eclipse/jnosql/tck/DocumentDatabase.java
+++ b/jnosql-nosql-tck-runner/src/test/java/org/eclipse/jnosql/tck/DocumentDatabase.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-nosql-tck-runner/src/test/java/org/eclipse/jnosql/tck/JNoSQLTemplateSupplier.java
+++ b/jnosql-nosql-tck-runner/src/test/java/org/eclipse/jnosql/tck/JNoSQLTemplateSupplier.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-nosql-tck-runner/src/test/resources/META-INF/microprofile-config.properties
+++ b/jnosql-nosql-tck-runner/src/test/resources/META-INF/microprofile-config.properties
@@ -1,10 +1,10 @@
 #
 # Copyright (c) 2022 Contributors to the Eclipse Foundation
 #  All rights reserved. This program and the accompanying materials
-#  are made available under the terms of the Eclipse Public License v1.0
+#  are made available under the terms of the Eclipse Public License 2.0
 #  and Apache License v2.0 which accompanies this distribution.
-#  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-#  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+#  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+#  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
 #
 # You may elect to redistribute this code under either of these licenses.
 #

--- a/jnosql-static-metamodel/jnosql-metamodel-processor/pom.xml
+++ b/jnosql-static-metamodel/jnosql-metamodel-processor/pom.xml
@@ -1,10 +1,10 @@
 <!--
   ~  Copyright (c) 2017 Otávio Santana and others
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-static-metamodel/jnosql-metamodel-processor/src/main/java/org/eclipse/jnosql/metamodel/processor/AttributeElementType.java
+++ b/jnosql-static-metamodel/jnosql-metamodel-processor/src/main/java/org/eclipse/jnosql/metamodel/processor/AttributeElementType.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-static-metamodel/jnosql-metamodel-processor/src/main/java/org/eclipse/jnosql/metamodel/processor/BaseMappingModel.java
+++ b/jnosql-static-metamodel/jnosql-metamodel-processor/src/main/java/org/eclipse/jnosql/metamodel/processor/BaseMappingModel.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-static-metamodel/jnosql-metamodel-processor/src/main/java/org/eclipse/jnosql/metamodel/processor/BasicPrimitiveNumber.java
+++ b/jnosql-static-metamodel/jnosql-metamodel-processor/src/main/java/org/eclipse/jnosql/metamodel/processor/BasicPrimitiveNumber.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-static-metamodel/jnosql-metamodel-processor/src/main/java/org/eclipse/jnosql/metamodel/processor/ClassAnalyzer.java
+++ b/jnosql-static-metamodel/jnosql-metamodel-processor/src/main/java/org/eclipse/jnosql/metamodel/processor/ClassAnalyzer.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-static-metamodel/jnosql-metamodel-processor/src/main/java/org/eclipse/jnosql/metamodel/processor/EntityModel.java
+++ b/jnosql-static-metamodel/jnosql-metamodel-processor/src/main/java/org/eclipse/jnosql/metamodel/processor/EntityModel.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-static-metamodel/jnosql-metamodel-processor/src/main/java/org/eclipse/jnosql/metamodel/processor/EntityProcessor.java
+++ b/jnosql-static-metamodel/jnosql-metamodel-processor/src/main/java/org/eclipse/jnosql/metamodel/processor/EntityProcessor.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-static-metamodel/jnosql-metamodel-processor/src/main/java/org/eclipse/jnosql/metamodel/processor/FieldAnalyzer.java
+++ b/jnosql-static-metamodel/jnosql-metamodel-processor/src/main/java/org/eclipse/jnosql/metamodel/processor/FieldAnalyzer.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-static-metamodel/jnosql-metamodel-processor/src/main/java/org/eclipse/jnosql/metamodel/processor/FieldModel.java
+++ b/jnosql-static-metamodel/jnosql-metamodel-processor/src/main/java/org/eclipse/jnosql/metamodel/processor/FieldModel.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-static-metamodel/jnosql-metamodel-processor/src/main/java/org/eclipse/jnosql/metamodel/processor/ProcessorUtil.java
+++ b/jnosql-static-metamodel/jnosql-metamodel-processor/src/main/java/org/eclipse/jnosql/metamodel/processor/ProcessorUtil.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-static-metamodel/jnosql-metamodel-processor/src/main/java/org/eclipse/jnosql/metamodel/processor/ValidationException.java
+++ b/jnosql-static-metamodel/jnosql-metamodel-processor/src/main/java/org/eclipse/jnosql/metamodel/processor/ValidationException.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-static-metamodel/jnosql-metamodel-processor/src/main/resources/metamodel.mustache
+++ b/jnosql-static-metamodel/jnosql-metamodel-processor/src/main/resources/metamodel.mustache
@@ -1,10 +1,10 @@
 /*
 *  Copyright (c) 2023 Otávio Santana and others
 *   All rights reserved. This program and the accompanying materials
-*   are made available under the terms of the Eclipse Public License v1.0
+*   are made available under the terms of the Eclipse Public License 2.0
 *   and Apache License v2.0 which accompanies this distribution.
-*   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-*   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+*   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+*   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
 *
 *   You may elect to redistribute this code under either of these licenses.
 *

--- a/jnosql-static-metamodel/jnosql-metamodel-sample/pom.xml
+++ b/jnosql-static-metamodel/jnosql-metamodel-sample/pom.xml
@@ -1,10 +1,10 @@
 <!--
   ~  Copyright (c) 2017 Otávio Santana and others
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-static-metamodel/jnosql-metamodel-sample/src/main/java/org/eclipse/jnsoql/entities/Car.java
+++ b/jnosql-static-metamodel/jnosql-metamodel-sample/src/main/java/org/eclipse/jnsoql/entities/Car.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-static-metamodel/jnosql-metamodel-sample/src/main/java/org/eclipse/jnsoql/entities/Checkout.java
+++ b/jnosql-static-metamodel/jnosql-metamodel-sample/src/main/java/org/eclipse/jnsoql/entities/Checkout.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-static-metamodel/jnosql-metamodel-sample/src/main/java/org/eclipse/jnsoql/entities/Driver.java
+++ b/jnosql-static-metamodel/jnosql-metamodel-sample/src/main/java/org/eclipse/jnsoql/entities/Driver.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-static-metamodel/jnosql-metamodel-sample/src/main/java/org/eclipse/jnsoql/entities/Fruit.java
+++ b/jnosql-static-metamodel/jnosql-metamodel-sample/src/main/java/org/eclipse/jnsoql/entities/Fruit.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-static-metamodel/jnosql-metamodel-sample/src/main/java/org/eclipse/jnsoql/entities/Person.java
+++ b/jnosql-static-metamodel/jnosql-metamodel-sample/src/main/java/org/eclipse/jnsoql/entities/Person.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-static-metamodel/jnosql-metamodel-sample/src/main/java/org/eclipse/jnsoql/entities/PrimitiveNumber.java
+++ b/jnosql-static-metamodel/jnosql-metamodel-sample/src/main/java/org/eclipse/jnsoql/entities/PrimitiveNumber.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-static-metamodel/jnosql-metamodel-sample/src/main/java/org/eclipse/jnsoql/entities/Product.java
+++ b/jnosql-static-metamodel/jnosql-metamodel-sample/src/main/java/org/eclipse/jnsoql/entities/Product.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-static-metamodel/jnosql-metamodel-sample/src/main/java/org/eclipse/jnsoql/entities/SoccerPlayer.java
+++ b/jnosql-static-metamodel/jnosql-metamodel-sample/src/main/java/org/eclipse/jnsoql/entities/SoccerPlayer.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-static-metamodel/jnosql-metamodel-sample/src/main/java/org/eclipse/jnsoql/entities/SoccerTeam.java
+++ b/jnosql-static-metamodel/jnosql-metamodel-sample/src/main/java/org/eclipse/jnsoql/entities/SoccerTeam.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-static-metamodel/jnosql-metamodel-sample/src/main/java/org/eclipse/jnsoql/entities/Vehicle.java
+++ b/jnosql-static-metamodel/jnosql-metamodel-sample/src/main/java/org/eclipse/jnsoql/entities/Vehicle.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-static-metamodel/jnosql-metamodel-sample/src/main/java/org/eclipse/jnsoql/entities/WishList.java
+++ b/jnosql-static-metamodel/jnosql-metamodel-sample/src/main/java/org/eclipse/jnsoql/entities/WishList.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-static-metamodel/jnosql-metamodel-sample/src/main/java/org/eclipse/jnsoql/entities/WrapperNumber.java
+++ b/jnosql-static-metamodel/jnosql-metamodel-sample/src/main/java/org/eclipse/jnsoql/entities/WrapperNumber.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-static-metamodel/jnosql-metamodel-sample/src/test/java/org/eclipse/jnsoql/entities/CarTest.java
+++ b/jnosql-static-metamodel/jnosql-metamodel-sample/src/test/java/org/eclipse/jnsoql/entities/CarTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-static-metamodel/jnosql-metamodel-sample/src/test/java/org/eclipse/jnsoql/entities/CheckoutTest.java
+++ b/jnosql-static-metamodel/jnosql-metamodel-sample/src/test/java/org/eclipse/jnsoql/entities/CheckoutTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-static-metamodel/jnosql-metamodel-sample/src/test/java/org/eclipse/jnsoql/entities/FruitTest.java
+++ b/jnosql-static-metamodel/jnosql-metamodel-sample/src/test/java/org/eclipse/jnsoql/entities/FruitTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-static-metamodel/jnosql-metamodel-sample/src/test/java/org/eclipse/jnsoql/entities/PersonTest.java
+++ b/jnosql-static-metamodel/jnosql-metamodel-sample/src/test/java/org/eclipse/jnsoql/entities/PersonTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-static-metamodel/jnosql-metamodel-sample/src/test/java/org/eclipse/jnsoql/entities/PrimitiveNumberTest.java
+++ b/jnosql-static-metamodel/jnosql-metamodel-sample/src/test/java/org/eclipse/jnsoql/entities/PrimitiveNumberTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-static-metamodel/jnosql-metamodel-sample/src/test/java/org/eclipse/jnsoql/entities/SoccerTeamTest.java
+++ b/jnosql-static-metamodel/jnosql-metamodel-sample/src/test/java/org/eclipse/jnsoql/entities/SoccerTeamTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-static-metamodel/jnosql-metamodel-sample/src/test/java/org/eclipse/jnsoql/entities/VehicleTest.java
+++ b/jnosql-static-metamodel/jnosql-metamodel-sample/src/test/java/org/eclipse/jnsoql/entities/VehicleTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-static-metamodel/jnosql-metamodel-sample/src/test/java/org/eclipse/jnsoql/entities/WishListTest.java
+++ b/jnosql-static-metamodel/jnosql-metamodel-sample/src/test/java/org/eclipse/jnsoql/entities/WishListTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-static-metamodel/jnosql-metamodel-sample/src/test/java/org/eclipse/jnsoql/entities/WrapperNumberTest.java
+++ b/jnosql-static-metamodel/jnosql-metamodel-sample/src/test/java/org/eclipse/jnsoql/entities/WrapperNumberTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-static-metamodel/pom.xml
+++ b/jnosql-static-metamodel/pom.xml
@@ -3,10 +3,10 @@
   ~
   ~  Copyright (c) 2017 Otávio Santana and others
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-tinkerpop-connections/pom.xml
+++ b/jnosql-tinkerpop-connections/pom.xml
@@ -2,10 +2,10 @@
 <!--
   ~  Copyright (c) 2022 Contributors to the Eclipse Foundation
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-tinkerpop-connections/src/main/java/org/eclipse/jnosql/mapping/tinkerpop/connections/ArangoDBGraphConfiguration.java
+++ b/jnosql-tinkerpop-connections/src/main/java/org/eclipse/jnosql/mapping/tinkerpop/connections/ArangoDBGraphConfiguration.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop-connections/src/main/java/org/eclipse/jnosql/mapping/tinkerpop/connections/ArangoDBGraphConfigurations.java
+++ b/jnosql-tinkerpop-connections/src/main/java/org/eclipse/jnosql/mapping/tinkerpop/connections/ArangoDBGraphConfigurations.java
@@ -2,8 +2,8 @@
  *  Copyright (c) 2022 Eclipse Contribuitor
  * All rights reserved. This program and the accompanying materials
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *    You may elect to redistribute this code under either of these licenses.
  */
 

--- a/jnosql-tinkerpop-connections/src/main/java/org/eclipse/jnosql/mapping/tinkerpop/connections/JanusGraphConfiguration.java
+++ b/jnosql-tinkerpop-connections/src/main/java/org/eclipse/jnosql/mapping/tinkerpop/connections/JanusGraphConfiguration.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop-connections/src/main/java/org/eclipse/jnosql/mapping/tinkerpop/connections/Neo4JEmbeddedGraphConfiguration.java
+++ b/jnosql-tinkerpop-connections/src/main/java/org/eclipse/jnosql/mapping/tinkerpop/connections/Neo4JEmbeddedGraphConfiguration.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop-connections/src/main/java/org/eclipse/jnosql/mapping/tinkerpop/connections/Neo4JGraphConfiguration.java
+++ b/jnosql-tinkerpop-connections/src/main/java/org/eclipse/jnosql/mapping/tinkerpop/connections/Neo4JGraphConfiguration.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop-connections/src/main/java/org/eclipse/jnosql/mapping/tinkerpop/connections/Neo4JGraphConfigurations.java
+++ b/jnosql-tinkerpop-connections/src/main/java/org/eclipse/jnosql/mapping/tinkerpop/connections/Neo4JGraphConfigurations.java
@@ -2,8 +2,8 @@
  *  Copyright (c) 2022 Eclipse Contribuitor
  * All rights reserved. This program and the accompanying materials
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *    You may elect to redistribute this code under either of these licenses.
  */
 

--- a/jnosql-tinkerpop-connections/src/main/java/org/eclipse/jnosql/mapping/tinkerpop/connections/TitanGraphConfiguration.java
+++ b/jnosql-tinkerpop-connections/src/main/java/org/eclipse/jnosql/mapping/tinkerpop/connections/TitanGraphConfiguration.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop-connections/src/main/java/org/eclipse/jnosql/mapping/tinkerpop/connections/package-info.java
+++ b/jnosql-tinkerpop-connections/src/main/java/org/eclipse/jnosql/mapping/tinkerpop/connections/package-info.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop-connections/src/test/resources/META-INF/beans.xml
+++ b/jnosql-tinkerpop-connections/src/test/resources/META-INF/beans.xml
@@ -1,10 +1,10 @@
 <!--
   ~  Copyright (c) 2022 Contributors to the Eclipse Foundation
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/pom.xml
+++ b/pom.xml
@@ -2,10 +2,10 @@
 <!--
   ~  Copyright (c) 2022,2025 Contributors to the Eclipse Foundation
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~


### PR DESCRIPTION
This pull request updates the license references across multiple files in the project to point to the newer Eclipse Public License 2.0 and the correct Apache License 2.0 URLs. No logic or functional code changes are introduced—this is a documentation and legal update to ensure compliance and accuracy.

**License and documentation updates:**

* Updated all copyright and license headers in Java source files and `pom.xml` files to reference the Eclipse Public License 2.0 instead of v1.0, and updated the URLs for both the Eclipse and Apache licenses to their current locations. [[1]](diffhunk://#diff-556bea72b3e7945f6295250897f4da2ee62876da56a6d324a47ddb8de55da9b2L4-R7) [[2]](diffhunk://#diff-a584ffb9b6419e14a1b62f48e6c02f2004e21b183ddf22792053d2d0294d03d6L4-R7) [[3]](diffhunk://#diff-fdf9a002b047b662c08094ec1202861fce20c17c5ecf6c1f8f82cbacdcc76b45L4-R7) [[4]](diffhunk://#diff-028926cb3bf1bcb487faf2af6c10c8ac6c5ca992eb067dc27e5fa6addd24c0deL4-R7) [[5]](diffhunk://#diff-5420e877875a41d0c4d4b13c4b9de7ea0dacfe0bf523d9a903763f216391e8fcL4-R7) [[6]](diffhunk://#diff-524553d1ff41954988a586f326a5d08285fc98660fc17303a6293d8625f8e2a3L4-R7) [[7]](diffhunk://#diff-bc5676b85eb008b87a51ee3775b3bf76351424d0aae58e2148e613f68260e76dL4-R7) [[8]](diffhunk://#diff-a1790c4f0708bbec2ff2f96e52418c0e4ebccdb4461169d73a5cfc2c8b42671aL4-R7) [[9]](diffhunk://#diff-ced754f967b798bba0d35612100f64c181cb6328705b1f89ed4ed3a6ffff1651L4-R7) [[10]](diffhunk://#diff-36255da5245ed2cb9679dcb35b8c7da7d9ce63752f38379811a35c93af50d996L4-R7) [[11]](diffhunk://#diff-07030313d66560a25b6af392dbca61e320024612d191f34bdc88e18a5a710982L4-R7) [[12]](diffhunk://#diff-2dea620c5d0b9f6b9bf836d5d959dc1103a93716694f0f88531706ce5896835eL4-R7) [[13]](diffhunk://#diff-de2400d0e4e14837a75bd6cd0a1c58a5c7874df36a30778eb9aacd3b3f86a515L4-R7) [[14]](diffhunk://#diff-eb2934a1aadff23799d2b43e805a94973b276afb0b3264ac75737164b1f32cc5L4-R7) [[15]](diffhunk://#diff-858057d76c83e1065c03a089080383cf4fe7b80b0f9cc83110e55018f6ccd75cL4-R7) [[16]](diffhunk://#diff-cacb9f2afbb497df2922dbc7c4e3b4c12a069cc03c06b3ba29bc7cfb47a84f6bL4-R7) [[17]](diffhunk://#diff-aa2e179e4995501ecaac595178d28b6e49c3ca16ab5098d6bf3a23434b2f4240L4-R7) [[18]](diffhunk://#diff-cd7d541e25c49d5019f85840d40c4740d58001145e49ac1b6ee33807e39c6728L5-R8) [[19]](diffhunk://#diff-72be70ac94b01a22f0192470d335d9e18459664ce70f5c9d370cc979b8a76612L6-R9) [[20]](diffhunk://#diff-a036342e5c2755aa0fd2562a028161db5690d3a7517f37cbfb60b3a74aafdd77L6-R9)