### PR TITLE
docs: update license headers to Eclipse Public License 2.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-This program and the accompanying materials are made available under the terms of the Eclipse Public License 1.0 which is available at http://www.eclipse.org/legal/epl-v10.html, or the Apache Software License 2.0 which is available at https://www.apache.org/licenses/LICENSE-2.0.
+This program and the accompanying materials are made available under the terms of the Eclipse Public License 1.0 which is available at https://www.eclipse.org/legal/epl-2.0, or the Apache Software License 2.0 which is available at https://www.apache.org/licenses/LICENSE-2.0.
 
 Eclipse Public License - v 1.0
 

--- a/jnosql-data-tck-runner/pom.xml
+++ b/jnosql-data-tck-runner/pom.xml
@@ -3,10 +3,10 @@
   ~
   ~  Copyright (c) 2024 Contributors to the Eclipse Foundation
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-data-tck-runner/src/test/java/org/eclipse/jnosql/tck/DocumentDatabase.java
+++ b/jnosql-data-tck-runner/src/test/java/org/eclipse/jnosql/tck/DocumentDatabase.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-data-tck-runner/src/test/java/org/eclipse/jnosql/tck/MyEntityTests.java
+++ b/jnosql-data-tck-runner/src/test/java/org/eclipse/jnosql/tck/MyEntityTests.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-data-tck-runner/src/test/java/org/eclipse/jnosql/tck/MyNoSQLEntityTests.java
+++ b/jnosql-data-tck-runner/src/test/java/org/eclipse/jnosql/tck/MyNoSQLEntityTests.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/pom.xml
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/pom.xml
@@ -3,10 +3,10 @@
 ~
 ~  Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
 ~   All rights reserved. This program and the accompanying materials
-~   are made available under the terms of the Eclipse Public License v1.0
+~   are made available under the terms of the Eclipse Public License 2.0
 ~   and Apache License v2.0 which accompanies this distribution.
-~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
 ~
 ~   You may elect to redistribute this code under either of these licenses.
 ~

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/src/test/java/org/eclipse/jnosql/tck/jakartapersistence/EntityManagerProducer.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/src/test/java/org/eclipse/jnosql/tck/jakartapersistence/EntityManagerProducer.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/src/test/java/org/eclipse/jnosql/tck/jakartapersistence/JNoSqlEntityTests.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/src/test/java/org/eclipse/jnosql/tck/jakartapersistence/JNoSqlEntityTests.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/src/test/java/org/eclipse/jnosql/tck/jakartapersistence/JNoSqlNoGlobalTxPersistenceEntityTests.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/src/test/java/org/eclipse/jnosql/tck/jakartapersistence/JNoSqlNoGlobalTxPersistenceEntityTests.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/src/test/java/org/eclipse/jnosql/tck/jakartapersistence/JNoSqlPersistenceEntityTests.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/src/test/java/org/eclipse/jnosql/tck/jakartapersistence/JNoSqlPersistenceEntityTests.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/src/test/java/org/eclipse/jnosql/tck/jakartapersistence/JNoSqlSignatureTests.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/src/test/java/org/eclipse/jnosql/tck/jakartapersistence/JNoSqlSignatureTests.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/src/test/java/org/eclipse/jnosql/tck/jakartapersistence/TransactionExtension.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/src/test/java/org/eclipse/jnosql/tck/jakartapersistence/TransactionExtension.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/src/test/java/org/eclipse/jnosql/tck/jakartapersistence/junit/RunOnly.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/src/test/java/org/eclipse/jnosql/tck/jakartapersistence/junit/RunOnly.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/src/test/java/org/eclipse/jnosql/tck/jakartapersistence/junit/RunOnlyCondition.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/src/test/java/org/eclipse/jnosql/tck/jakartapersistence/junit/RunOnlyCondition.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/src/test/resources/META-INF/persistence.xml
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/src/test/resources/META-INF/persistence.xml
@@ -3,10 +3,10 @@
   ~
   ~  Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/pom.xml
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/pom.xml
@@ -3,10 +3,10 @@
   ~
   ~  Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/CdiUtil.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/CdiUtil.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/JNoSQLJakartaPersistence.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/JNoSQLJakartaPersistence.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/communication/EntityManagerProvider.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/communication/EntityManagerProvider.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/communication/JakartaPersistenceEntitiesMetadata.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/communication/JakartaPersistenceEntitiesMetadata.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2024 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/communication/PersistenceDatabaseManager.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/communication/PersistenceDatabaseManager.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/communication/PersistenceDatabaseManagerProvider.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/communication/PersistenceDatabaseManagerProvider.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2024 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/BaseQueryParser.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/BaseQueryParser.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/BaseUpdateQueryParser.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/BaseUpdateQueryParser.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/DataExceptions.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/DataExceptions.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/DeleteQueryParser.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/DeleteQueryParser.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/EnsureTransaction.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/EnsureTransaction.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/EnsureTransactionInterceptor.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/EnsureTransactionInterceptor.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/PersistenceDocumentTemplate.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/PersistenceDocumentTemplate.java
@@ -2,10 +2,10 @@
  *   Copyright (c) 2024, 2025 Contributors to the Eclipse Foundation.
  *   
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/PersistencePreparedStatement.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/PersistencePreparedStatement.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/QLUtil.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/QLUtil.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2024,2026 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/QueryModifier.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/QueryModifier.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/SelectQueryParser.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/SelectQueryParser.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/UpdateQueryParser.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/UpdateQueryParser.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/cache/MapBasedPersistenceUnitCache.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/cache/MapBasedPersistenceUnitCache.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2024 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/cache/PersistenceUnitCache.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/cache/PersistenceUnitCache.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2024 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/cache/PersistenceUnitCacheProvider.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/cache/PersistenceUnitCacheProvider.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2024 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/core/PersistencePage.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/core/PersistencePage.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/metadata/JakartaPersistenceClassScanner.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/metadata/JakartaPersistenceClassScanner.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2024 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/parser/OptionalPartsParser.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/parser/OptionalPartsParser.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2025 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/repository/AbstractRepositoryPersistenceBean.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/repository/AbstractRepositoryPersistenceBean.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2025 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/repository/CustomRepositoryPersistenceBean.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/repository/CustomRepositoryPersistenceBean.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/repository/CustomRepositoryPersistenceHandler.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/repository/CustomRepositoryPersistenceHandler.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/repository/CustomRepositoryPersistenceHandlerBuilder.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/repository/CustomRepositoryPersistenceHandlerBuilder.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/repository/InterceptorInvocationContext.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/repository/InterceptorInvocationContext.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/repository/JakartaPersistenceDefaultRepositoryReturn.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/repository/JakartaPersistenceDefaultRepositoryReturn.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/repository/JakartaPersistenceDynamicQueryMethodReturn.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/repository/JakartaPersistenceDynamicQueryMethodReturn.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022,2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/repository/JakartaPersistenceDynamicReturnConverter.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/repository/JakartaPersistenceDynamicReturnConverter.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022,2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/repository/JakartaPersistenceParameterBasedQuery.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/repository/JakartaPersistenceParameterBasedQuery.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023,2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/repository/JakartaPersistenceRepositoryProxy.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/repository/JakartaPersistenceRepositoryProxy.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/repository/MethodInterceptorProxy.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/repository/MethodInterceptorProxy.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2025 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/repository/RepositoryPersistenceBean.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/repository/RepositoryPersistenceBean.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/spi/JakartaPersistenceExtension.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/spi/JakartaPersistenceExtension.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022,2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/spi/MethodInterceptor.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/spi/MethodInterceptor.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/resources/META-INF/beans.xml
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/resources/META-INF/beans.xml
@@ -3,10 +3,10 @@
   ~
   ~  Copyright (c) 2024 Contributors to the Eclipse Foundation
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/resources/META-INF/services/jakarta.enterprise.inject.spi.Extension
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/resources/META-INF/services/jakarta.enterprise.inject.spi.Extension
@@ -1,10 +1,10 @@
 #
 #  Copyright (c) 2022 Contributors to the Eclipse Foundation
 #   All rights reserved. This program and the accompanying materials
-#   are made available under the terms of the Eclipse Public License v1.0
+#   are made available under the terms of the Eclipse Public License 2.0
 #   and Apache License v2.0 which accompanies this distribution.
-#   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-#   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+#   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+#   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
 #
 #   You may elect to redistribute this code under either of these licenses.
 #

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/AmbiguousEntityManagerRepository.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/AmbiguousEntityManagerRepository.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/AmbiguousEntityManagerTest.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/AmbiguousEntityManagerTest.java
@@ -1,8 +1,8 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
- *   and Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   are made available under the terms of the Eclipse Public License 2.0
+ *   and Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/CallCountInterceptor.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/CallCountInterceptor.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/CallCounter.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/CallCounter.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/CountCalls.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/CountCalls.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/CountedPersonRepository.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/CountedPersonRepository.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/CustomDefaultEntityManagerRepository.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/CustomDefaultEntityManagerRepository.java
@@ -1,8 +1,8 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
- *   and Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   are made available under the terms of the Eclipse Public License 2.0
+ *   and Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/CustomDefaultEntityManagerTest.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/CustomDefaultEntityManagerTest.java
@@ -1,8 +1,8 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
- *   and Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   are made available under the terms of the Eclipse Public License 2.0
+ *   and Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/CustomEntityManagerAccessRepository.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/CustomEntityManagerAccessRepository.java
@@ -1,8 +1,8 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
- *   and Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   are made available under the terms of the Eclipse Public License 2.0
+ *   and Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/CustomEntityManagerAccessTest.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/CustomEntityManagerAccessTest.java
@@ -1,8 +1,8 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
- *   and Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   are made available under the terms of the Eclipse Public License 2.0
+ *   and Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/CustomEntityManagerRepository.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/CustomEntityManagerRepository.java
@@ -1,8 +1,8 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
- *   and Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   are made available under the terms of the Eclipse Public License 2.0
+ *   and Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/CustomPersonRepository.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/CustomPersonRepository.java
@@ -1,8 +1,8 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
- *   and Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   are made available under the terms of the Eclipse Public License 2.0
+ *   and Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/CustomQualifiedEntityManagerRepository.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/CustomQualifiedEntityManagerRepository.java
@@ -1,8 +1,8 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
- *   and Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   are made available under the terms of the Eclipse Public License 2.0
+ *   and Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/CustomRepositoryInterceptorTest.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/CustomRepositoryInterceptorTest.java
@@ -1,8 +1,8 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
- *   and Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   are made available under the terms of the Eclipse Public License 2.0
+ *   and Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/EntityManagerAccessRepository.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/EntityManagerAccessRepository.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/EntityManagerAccessTest.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/EntityManagerAccessTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/EntityManagerProducer.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/EntityManagerProducer.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/InterceptorTest.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/InterceptorTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/MethodInterceptedPersonRepository.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/MethodInterceptedPersonRepository.java
@@ -1,8 +1,8 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
- *   and Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   are made available under the terms of the Eclipse Public License 2.0
+ *   and Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/MethodInterceptorTest.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/MethodInterceptorTest.java
@@ -1,8 +1,8 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
- *   and Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   are made available under the terms of the Eclipse Public License 2.0
+ *   and Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/MixedInterceptorPersonRepository.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/MixedInterceptorPersonRepository.java
@@ -1,8 +1,8 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
- *   and Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   are made available under the terms of the Eclipse Public License 2.0
+ *   and Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/MixedInterceptorTest.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/MixedInterceptorTest.java
@@ -1,8 +1,8 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
- *   and Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   are made available under the terms of the Eclipse Public License 2.0
+ *   and Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/PageOutsideTransactionTest.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/PageOutsideTransactionTest.java
@@ -2,9 +2,9 @@
  * Copyright (c) 2026 Contributors to the Eclipse Foundation
  *
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License 2.0
  * and Apache License v2.0 which accompanies this distribution.
- * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
  * and the Apache License v2.0 which accompanies this distribution.
  *
  * You may elect to redistribute this code under either of these licenses.

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/PagePersonRepository.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/PagePersonRepository.java
@@ -2,9 +2,9 @@
  * Copyright (c) 2026 Contributors to the Eclipse Foundation
  *
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License 2.0
  * and Apache License v2.0 which accompanies this distribution.
- * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
  * and the Apache License v2.0 which accompanies this distribution.
  *
  * You may elect to redistribute this code under either of these licenses.

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/Person.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/Person.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/PersonRepository.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/PersonRepository.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/PersonRepositoryTest.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/PersonRepositoryTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/QualifiedEntityManagerRepository.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/QualifiedEntityManagerRepository.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/QualifiedPersonRepository.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/QualifiedPersonRepository.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/QualifierTest.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/QualifierTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/SpecialEntityManager.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/SpecialEntityManager.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/SpecialRepository.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/SpecialRepository.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/TestJakartaPersistenceClassScanner.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/TestJakartaPersistenceClassScanner.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2024 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/TestSupport.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/TestSupport.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2024 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/jakartapersistence/mapping/QLUtilTest.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/jakartapersistence/mapping/QLUtilTest.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2024,2026 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/jakartapersistence/mapping/parser/OptionalPartsParserTest.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/jakartapersistence/mapping/parser/OptionalPartsParserTest.java
@@ -2,10 +2,10 @@
  * Copyright (c) 2025 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *  You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/resources/META-INF/persistence.xml
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/resources/META-INF/persistence.xml
@@ -3,10 +3,10 @@
   ~
   ~  Copyright (c) 2024 Contributors to the Eclipse Foundation
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-scanner/pom.xml
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-scanner/pom.xml
@@ -3,10 +3,10 @@
   ~
   ~  Copyright (c) 2024, 2025 Contributors to the Eclipse Foundation
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-scanner/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/reflection/PersistenceClassScannerSingleton.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-scanner/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/reflection/PersistenceClassScannerSingleton.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-scanner/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/reflection/PersistenceRepositoryFilter.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-scanner/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/reflection/PersistenceRepositoryFilter.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023, 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-scanner/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/reflection/ReflectionJakartaPersistenceClassScanner.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-scanner/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/reflection/ReflectionJakartaPersistenceClassScanner.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-scanner/src/test/java/org/eclipse/jnosql/jakartapersistence/mapping/reflection/EntityManagerProducer.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-scanner/src/test/java/org/eclipse/jnosql/jakartapersistence/mapping/reflection/EntityManagerProducer.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-scanner/src/test/java/org/eclipse/jnosql/jakartapersistence/mapping/reflection/ProviderTest.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-scanner/src/test/java/org/eclipse/jnosql/jakartapersistence/mapping/reflection/ProviderTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-scanner/src/test/java/org/eclipse/jnosql/jakartapersistence/mapping/reflection/SupportedRepository.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-scanner/src/test/java/org/eclipse/jnosql/jakartapersistence/mapping/reflection/SupportedRepository.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-scanner/src/test/java/org/eclipse/jnosql/jakartapersistence/mapping/reflection/UnsupportedRepository.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-scanner/src/test/java/org/eclipse/jnosql/jakartapersistence/mapping/reflection/UnsupportedRepository.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-scanner/src/test/resources/META-INF/persistence.xml
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-scanner/src/test/resources/META-INF/persistence.xml
@@ -3,10 +3,10 @@
   ~
   ~  Copyright (c) 2024 Contributors to the Eclipse Foundation
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-jakarta-persistence/pom.xml
+++ b/jnosql-jakarta-persistence/pom.xml
@@ -3,10 +3,10 @@
   ~
   ~  Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-lite/mapping-lite-column-test/pom.xml
+++ b/jnosql-lite/mapping-lite-column-test/pom.xml
@@ -1,10 +1,10 @@
 <!--
   ~  Copyright (c) 2021 Otávio Santana and others
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Actor.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Actor.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/ActorBuilder.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/ActorBuilder.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Address.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Address.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/AppointmentBook.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/AppointmentBook.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Citizen.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Citizen.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/City.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/City.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Contact.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Contact.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/ContactType.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/ContactType.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Director.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Director.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Download.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Download.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Job.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Job.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Money.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Money.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/MoneyConverter.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/MoneyConverter.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Movie.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Movie.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Person.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Person.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/PersonBuilder.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/PersonBuilder.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/PersonCrudRepository.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/PersonCrudRepository.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/PersonRepository.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/PersonRepository.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/UserScope.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/UserScope.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Vendor.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Vendor.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Wine.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Wine.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/WineFactory.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/WineFactory.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Worker.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Worker.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/ZipCode.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/ZipCode.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/EmailNotification.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/EmailNotification.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/LargeProject.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/LargeProject.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/Notification.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/Notification.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/NotificationReader.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/NotificationReader.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/Project.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/Project.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/ProjectManager.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/ProjectManager.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/SmallProject.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/SmallProject.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/SmsNotification.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/SmsNotification.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/SocialMediaNotification.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/SocialMediaNotification.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/record/Guest.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/record/Guest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/record/Hotel.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/record/Hotel.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/record/HotelManager.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/record/HotelManager.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/record/Room.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/record/Room.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/ColumnEntityConverterInheritanceTest.java
+++ b/jnosql-lite/mapping-lite-column-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/ColumnEntityConverterInheritanceTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/ColumnEntityConverterRecordTest.java
+++ b/jnosql-lite/mapping-lite-column-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/ColumnEntityConverterRecordTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/ColumnEntityConverterTest.java
+++ b/jnosql-lite/mapping-lite-column-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/ColumnEntityConverterTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/PersonCrudRepositoryTest.java
+++ b/jnosql-lite/mapping-lite-column-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/PersonCrudRepositoryTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-column-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/PersonRepositoryTest.java
+++ b/jnosql-lite/mapping-lite-column-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/PersonRepositoryTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/pom.xml
+++ b/jnosql-lite/mapping-lite-core-test/pom.xml
@@ -1,10 +1,10 @@
 <!--
   ~  Copyright (c) 2017 Otávio Santana and others
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Actor.java
+++ b/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Actor.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Animal.java
+++ b/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Animal.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2020 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Car.java
+++ b/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Car.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2020 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Computer.java
+++ b/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Computer.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2020 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/ComputerAddress.java
+++ b/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/ComputerAddress.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/CustomAnnotation.java
+++ b/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/CustomAnnotation.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Director.java
+++ b/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Director.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2020 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Money.java
+++ b/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Money.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2020 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/MoneyConverter.java
+++ b/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/MoneyConverter.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2020 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Movie.java
+++ b/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Movie.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2020 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Order.java
+++ b/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Order.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Orders.java
+++ b/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Orders.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2020 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Person.java
+++ b/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Person.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2020 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Product.java
+++ b/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Product.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2020 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/User.java
+++ b/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/User.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Wine.java
+++ b/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Wine.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/WineFactory.java
+++ b/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/WineFactory.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Worker.java
+++ b/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Worker.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/EmailNotification.java
+++ b/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/EmailNotification.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/LargeProject.java
+++ b/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/LargeProject.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/Notification.java
+++ b/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/Notification.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/Project.java
+++ b/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/Project.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/SmallProject.java
+++ b/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/SmallProject.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/SmsNotification.java
+++ b/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/SmsNotification.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/SocialMediaNotification.java
+++ b/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/SocialMediaNotification.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/record/Apartment.java
+++ b/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/record/Apartment.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/record/Building.java
+++ b/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/record/Building.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/record/DocumentRecord.java
+++ b/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/record/DocumentRecord.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/record/Guest.java
+++ b/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/record/Guest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/record/Hotel.java
+++ b/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/record/Hotel.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/record/House.java
+++ b/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/record/House.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/record/Room.java
+++ b/jnosql-lite/mapping-lite-core-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/record/Room.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/ActorTest.java
+++ b/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/ActorTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2020 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/AnimalTest.java
+++ b/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/AnimalTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2020 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/CarTest.java
+++ b/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/CarTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2020 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/ComputerTest.java
+++ b/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/ComputerTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/EntitiesMetadataTest.java
+++ b/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/EntitiesMetadataTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2020 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/MovieTest.java
+++ b/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/MovieTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2020 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/OrderTest.java
+++ b/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/OrderTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2020 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/OrdersTest.java
+++ b/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/OrdersTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/PersonTest.java
+++ b/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/PersonTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2020 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/UserTest.java
+++ b/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/UserTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2020 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/WineTest.java
+++ b/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/WineTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/WorkerTest.java
+++ b/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/WorkerTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2020 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/EmailNotificationTest.java
+++ b/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/EmailNotificationTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/LargeProjectTest.java
+++ b/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/LargeProjectTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/NotificationTest.java
+++ b/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/NotificationTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/ProjectTest.java
+++ b/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/ProjectTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/SMSNotificationTest.java
+++ b/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/SMSNotificationTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/SmallProjectTest.java
+++ b/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/SmallProjectTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/SocialMediaNotificationTest.java
+++ b/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/SocialMediaNotificationTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/record/ApartmentTest.java
+++ b/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/record/ApartmentTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/record/BuildingTest.java
+++ b/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/record/BuildingTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/record/DocumentRecordTest.java
+++ b/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/record/DocumentRecordTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/record/GuestTest.java
+++ b/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/record/GuestTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/record/HotelTest.java
+++ b/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/record/HotelTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/record/RoomTest.java
+++ b/jnosql-lite/mapping-lite-core-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/record/RoomTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/pom.xml
+++ b/jnosql-lite/mapping-lite-document-test/pom.xml
@@ -1,10 +1,10 @@
 <!--
   ~  Copyright (c) 2021 Otávio Santana and others
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Actor.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Actor.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/ActorBuilder.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/ActorBuilder.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Address.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Address.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/AppointmentBook.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/AppointmentBook.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Citizen.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Citizen.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/City.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/City.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Contact.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Contact.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/ContactType.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/ContactType.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Director.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Director.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Download.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Download.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Job.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Job.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Money.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Money.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/MoneyConverter.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/MoneyConverter.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Movie.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Movie.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Person.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Person.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/PersonBuilder.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/PersonBuilder.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/PersonCrudRepository.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/PersonCrudRepository.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/PersonRepository.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/PersonRepository.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/UserScope.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/UserScope.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Vendor.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Vendor.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Wine.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Wine.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/WineFactory.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/WineFactory.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Worker.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Worker.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/ZipCode.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/ZipCode.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/EmailNotification.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/EmailNotification.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/LargeProject.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/LargeProject.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/Notification.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/Notification.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/NotificationReader.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/NotificationReader.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/Project.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/Project.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/ProjectManager.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/ProjectManager.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/SmallProject.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/SmallProject.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/SmsNotification.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/SmsNotification.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/SocialMediaNotification.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/SocialMediaNotification.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/record/Guest.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/record/Guest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/record/Hotel.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/record/Hotel.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/record/HotelManager.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/record/HotelManager.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/record/Room.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/record/Room.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/DocumentEntityConverterInheritanceTest.java
+++ b/jnosql-lite/mapping-lite-document-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/DocumentEntityConverterInheritanceTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/DocumentEntityConverterRecordTest.java
+++ b/jnosql-lite/mapping-lite-document-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/DocumentEntityConverterRecordTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/DocumentEntityConverterTest.java
+++ b/jnosql-lite/mapping-lite-document-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/DocumentEntityConverterTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/PersonCrudRepositoryTest.java
+++ b/jnosql-lite/mapping-lite-document-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/PersonCrudRepositoryTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-document-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/PersonRepositoryTest.java
+++ b/jnosql-lite/mapping-lite-document-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/PersonRepositoryTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/pom.xml
+++ b/jnosql-lite/mapping-lite-graph-test/pom.xml
@@ -1,10 +1,10 @@
 <!--
   ~  Copyright (c) 2021 Otávio Santana and others
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Actor.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Actor.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/ActorBuilder.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/ActorBuilder.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Address.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Address.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/AppointmentBook.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/AppointmentBook.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Citizen.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Citizen.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/City.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/City.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Contact.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Contact.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/ContactType.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/ContactType.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Director.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Director.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Download.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Download.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Job.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Job.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Money.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Money.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/MoneyConverter.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/MoneyConverter.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Movie.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Movie.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Person.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Person.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/PersonBuilder.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/PersonBuilder.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/PersonCrudRepository.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/PersonCrudRepository.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/PersonRepository.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/PersonRepository.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/UserScope.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/UserScope.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Vendor.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Vendor.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Wine.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Wine.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/WineFactory.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/WineFactory.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Worker.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Worker.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/ZipCode.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/ZipCode.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/EmailNotification.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/EmailNotification.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/LargeProject.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/LargeProject.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/Notification.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/Notification.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/NotificationReader.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/NotificationReader.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/Project.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/Project.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/ProjectManager.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/ProjectManager.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/SmallProject.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/SmallProject.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/SmsNotification.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/SmsNotification.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/SocialMediaNotification.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/inheritance/SocialMediaNotification.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/record/Guest.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/record/Guest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/record/Hotel.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/record/Hotel.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/record/HotelManager.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/record/HotelManager.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/record/Room.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/record/Room.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/GraphEntityConverterInheritanceTest.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/GraphEntityConverterInheritanceTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/GraphEntityConverterRecordTest.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/GraphEntityConverterRecordTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/GraphEntityConverterTest.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/GraphEntityConverterTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/PersonCrudRepositoryTest.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/PersonCrudRepositoryTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-graph-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/PersonRepositoryTest.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/PersonRepositoryTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-key-value-test/pom.xml
+++ b/jnosql-lite/mapping-lite-key-value-test/pom.xml
@@ -1,10 +1,10 @@
 <!--
   ~  Copyright (c) 2021 Otávio Santana and others
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-lite/mapping-lite-key-value-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Car.java
+++ b/jnosql-lite/mapping-lite-key-value-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Car.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-key-value-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Job.java
+++ b/jnosql-lite/mapping-lite-key-value-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Job.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-key-value-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Money.java
+++ b/jnosql-lite/mapping-lite-key-value-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Money.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-key-value-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/MoneyConverter.java
+++ b/jnosql-lite/mapping-lite-key-value-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/MoneyConverter.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-key-value-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Person.java
+++ b/jnosql-lite/mapping-lite-key-value-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Person.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-key-value-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/PersonBuilder.java
+++ b/jnosql-lite/mapping-lite-key-value-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/PersonBuilder.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-key-value-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/PersonRepository.java
+++ b/jnosql-lite/mapping-lite-key-value-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/PersonRepository.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-key-value-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Plate.java
+++ b/jnosql-lite/mapping-lite-key-value-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Plate.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-key-value-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/PlateConverter.java
+++ b/jnosql-lite/mapping-lite-key-value-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/PlateConverter.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-key-value-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/User.java
+++ b/jnosql-lite/mapping-lite-key-value-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/User.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-key-value-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/UserCrudRepository.java
+++ b/jnosql-lite/mapping-lite-key-value-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/UserCrudRepository.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-key-value-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/UserRepository.java
+++ b/jnosql-lite/mapping-lite-key-value-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/UserRepository.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-key-value-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Worker.java
+++ b/jnosql-lite/mapping-lite-key-value-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Worker.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-key-value-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/KeyValueEntityConverterTest.java
+++ b/jnosql-lite/mapping-lite-key-value-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/KeyValueEntityConverterTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-key-value-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/PersonRepositoryTest.java
+++ b/jnosql-lite/mapping-lite-key-value-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/PersonRepositoryTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-key-value-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/UserCrudRepositoryLiteKeyValueTest.java
+++ b/jnosql-lite/mapping-lite-key-value-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/UserCrudRepositoryLiteKeyValueTest.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-key-value-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/UserRepositoryLiteKeyValueTest.java
+++ b/jnosql-lite/mapping-lite-key-value-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/UserRepositoryLiteKeyValueTest.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/pom.xml
+++ b/jnosql-lite/mapping-lite-processor/pom.xml
@@ -1,10 +1,10 @@
 <!--
   ~  Copyright (c) 2017 Otávio Santana and others
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/BaseMappingModel.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/BaseMappingModel.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2020 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/ClassAnalyzer.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/ClassAnalyzer.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2020 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/CollectionUtil.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/CollectionUtil.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/ConstructorMetamodel.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/ConstructorMetamodel.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/EntitiesMetadataModel.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/EntitiesMetadataModel.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2020 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/EntityModel.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/EntityModel.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2020 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/EntityProcessor.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/EntityProcessor.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2020 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/FieldAnalyzer.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/FieldAnalyzer.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2020 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/FieldModel.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/FieldModel.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2020 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/MetadataAppender.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/MetadataAppender.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2020 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/ParameterAnalyzer.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/ParameterAnalyzer.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2020 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/ParameterModel.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/ParameterModel.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2020 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/ParameterResult.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/ParameterResult.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/ProcessorUtil.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/ProcessorUtil.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2020 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/ValidationException.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/ValidationException.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2020 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/ValueAnnotationModel.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/ValueAnnotationModel.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/metadata/CollectionSupplierProvider.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/metadata/CollectionSupplierProvider.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2020 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/metadata/DefaultConstructorMetadata.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/metadata/DefaultConstructorMetadata.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/metadata/DequeSupplier.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/metadata/DequeSupplier.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2020 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/metadata/ListSupplier.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/metadata/ListSupplier.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2020 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/metadata/LiteClassConverter.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/metadata/LiteClassConverter.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/metadata/LiteClassScanner.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/metadata/LiteClassScanner.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/metadata/LiteConstructorBuilder.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/metadata/LiteConstructorBuilder.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/metadata/LiteConstructorBuilderSupplier.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/metadata/LiteConstructorBuilderSupplier.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/metadata/LiteConstructorMetadata.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/metadata/LiteConstructorMetadata.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/metadata/LiteEntityMetadata.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/metadata/LiteEntityMetadata.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/metadata/SetSupplier.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/metadata/SetSupplier.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2020 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/metadata/TreeSetSupplier.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/metadata/TreeSetSupplier.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2020 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/AnnotationOperationMethodBuilder.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/AnnotationOperationMethodBuilder.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/AnnotationQueryRepositoryReturnType.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/AnnotationQueryRepositoryReturnType.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2021 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/DatabaseSupport.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/DatabaseSupport.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/KeyValueMethodBuilder.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/KeyValueMethodBuilder.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2021 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/KeyValueMethodGenerator.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/KeyValueMethodGenerator.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2021 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/KeyValueRepositoryMetadata.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/KeyValueRepositoryMetadata.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2021 Otavio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/MethodGenerator.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/MethodGenerator.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2021 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/MethodMetadata.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/MethodMetadata.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2021 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/MethodMetadataOperationType.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/MethodMetadataOperationType.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/MethodQueryRepositoryReturnType.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/MethodQueryRepositoryReturnType.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2021 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/Parameter.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/Parameter.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2021 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/RepositoryAnalyzer.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/RepositoryAnalyzer.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2021 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/RepositoryElement.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/RepositoryElement.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2021 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/RepositoryMetadata.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/RepositoryMetadata.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2021 Otavio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/RepositoryProcessor.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/RepositoryProcessor.java
@@ -2,10 +2,10 @@
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *  Copyright (c) 2021 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/RepositoryTemplateType.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/RepositoryTemplateType.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2021 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/RepositoryUtil.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/RepositoryUtil.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2021 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/SemiStructureMethodGenerator.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/SemiStructureMethodGenerator.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2021 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/SemiStructureRepositoryMetadata.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/SemiStructureRepositoryMetadata.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2021 Otavio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/SemistructuredMethodBuilder.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/SemistructuredMethodBuilder.java
@@ -2,10 +2,10 @@
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *  Copyright (c) 2021 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/resources/constructor_metadata.mustache
+++ b/jnosql-lite/mapping-lite-processor/src/main/resources/constructor_metadata.mustache
@@ -1,10 +1,10 @@
 /*
 *  Copyright (c) 2023 Otávio Santana and others
 *   All rights reserved. This program and the accompanying materials
-*   are made available under the terms of the Eclipse Public License v1.0
+*   are made available under the terms of the Eclipse Public License 2.0
 *   and Apache License v2.0 which accompanies this distribution.
-*   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-*   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+*   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+*   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
 *
 *   You may elect to redistribute this code under either of these licenses.
 *

--- a/jnosql-lite/mapping-lite-processor/src/main/resources/entities_metadata.mustache
+++ b/jnosql-lite/mapping-lite-processor/src/main/resources/entities_metadata.mustache
@@ -1,10 +1,10 @@
 /*
 *  Copyright (c) 2023 Otávio Santana and others
 *   All rights reserved. This program and the accompanying materials
-*   are made available under the terms of the Eclipse Public License v1.0
+*   are made available under the terms of the Eclipse Public License 2.0
 *   and Apache License v2.0 which accompanies this distribution.
-*   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-*   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+*   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+*   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
 *
 *   You may elect to redistribute this code under either of these licenses.
 *

--- a/jnosql-lite/mapping-lite-processor/src/main/resources/entity_metadata.mustache
+++ b/jnosql-lite/mapping-lite-processor/src/main/resources/entity_metadata.mustache
@@ -1,10 +1,10 @@
 /*
 *  Copyright (c) 2023 Otávio Santana and others
 *   All rights reserved. This program and the accompanying materials
-*   are made available under the terms of the Eclipse Public License v1.0
+*   are made available under the terms of the Eclipse Public License 2.0
 *   and Apache License v2.0 which accompanies this distribution.
-*   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-*   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+*   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+*   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
 *
 *   You may elect to redistribute this code under either of these licenses.
 *

--- a/jnosql-lite/mapping-lite-processor/src/main/resources/field_array_metadata.mustache
+++ b/jnosql-lite/mapping-lite-processor/src/main/resources/field_array_metadata.mustache
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/resources/field_collection_metadata.mustache
+++ b/jnosql-lite/mapping-lite-processor/src/main/resources/field_collection_metadata.mustache
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/resources/field_map_metadata.mustache
+++ b/jnosql-lite/mapping-lite-processor/src/main/resources/field_map_metadata.mustache
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/resources/field_metadata.mustache
+++ b/jnosql-lite/mapping-lite-processor/src/main/resources/field_metadata.mustache
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/resources/parameter_array_metadata.mustache
+++ b/jnosql-lite/mapping-lite-processor/src/main/resources/parameter_array_metadata.mustache
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/resources/parameter_collection_metadata.mustache
+++ b/jnosql-lite/mapping-lite-processor/src/main/resources/parameter_collection_metadata.mustache
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/resources/parameter_map_metadata.mustache
+++ b/jnosql-lite/mapping-lite-processor/src/main/resources/parameter_map_metadata.mustache
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/resources/parameter_metadata.mustache
+++ b/jnosql-lite/mapping-lite-processor/src/main/resources/parameter_metadata.mustache
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/main/resources/repository_key-value.mustache
+++ b/jnosql-lite/mapping-lite-processor/src/main/resources/repository_key-value.mustache
@@ -1,10 +1,10 @@
 /*
 *  Copyright (c) 2021 Otávio Santana and others
 *   All rights reserved. This program and the accompanying materials
-*   are made available under the terms of the Eclipse Public License v1.0
+*   are made available under the terms of the Eclipse Public License 2.0
 *   and Apache License v2.0 which accompanies this distribution.
-*   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-*   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+*   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+*   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
 *
 *   You may elect to redistribute this code under either of these licenses.
 *

--- a/jnosql-lite/mapping-lite-processor/src/main/resources/repository_semi_structure.mustache
+++ b/jnosql-lite/mapping-lite-processor/src/main/resources/repository_semi_structure.mustache
@@ -2,10 +2,10 @@
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *  Copyright (c) 2021 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/test/java/org/eclipse/jnosql/lite/mapping/CollectionUtilTest.java
+++ b/jnosql-lite/mapping-lite-processor/src/test/java/org/eclipse/jnosql/lite/mapping/CollectionUtilTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/test/java/org/eclipse/jnosql/lite/mapping/LiteClassConverterTest.java
+++ b/jnosql-lite/mapping-lite-processor/src/test/java/org/eclipse/jnosql/lite/mapping/LiteClassConverterTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/test/java/org/eclipse/jnosql/lite/mapping/LiteClassScannerTest.java
+++ b/jnosql-lite/mapping-lite-processor/src/test/java/org/eclipse/jnosql/lite/mapping/LiteClassScannerTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/mapping-lite-processor/src/test/java/org/eclipse/jnosql/lite/mapping/LiteConstructorBuilderSupplierTest.java
+++ b/jnosql-lite/mapping-lite-processor/src/test/java/org/eclipse/jnosql/lite/mapping/LiteConstructorBuilderSupplierTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-lite/pom.xml
+++ b/jnosql-lite/pom.xml
@@ -3,10 +3,10 @@
   ~
   ~  Copyright (c) 2017 Otávio Santana and others
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-mapping-validation/pom.xml
+++ b/jnosql-mapping-validation/pom.xml
@@ -1,10 +1,10 @@
 <!--
   ~  Copyright (c) 2022 Contributors to the Eclipse Foundation
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-mapping-validation/src/main/java/org/eclipse/jnosql/mapping/validation/EntityObserver.java
+++ b/jnosql-mapping-validation/src/main/java/org/eclipse/jnosql/mapping/validation/EntityObserver.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-mapping-validation/src/main/java/org/eclipse/jnosql/mapping/validation/MappingValidator.java
+++ b/jnosql-mapping-validation/src/main/java/org/eclipse/jnosql/mapping/validation/MappingValidator.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-mapping-validation/src/main/resources/META-INF/beans.xml
+++ b/jnosql-mapping-validation/src/main/resources/META-INF/beans.xml
@@ -1,10 +1,10 @@
 <!--
   ~  Copyright (c) 2022 Contributors to the Eclipse Foundation
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-mapping-validation/src/test/java/org/eclipse/jnosql/mapping/validation/BucketManagerSupplier.java
+++ b/jnosql-mapping-validation/src/test/java/org/eclipse/jnosql/mapping/validation/BucketManagerSupplier.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-mapping-validation/src/test/java/org/eclipse/jnosql/mapping/validation/ColumnTemplateValidationTest.java
+++ b/jnosql-mapping-validation/src/test/java/org/eclipse/jnosql/mapping/validation/ColumnTemplateValidationTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-mapping-validation/src/test/java/org/eclipse/jnosql/mapping/validation/Computer.java
+++ b/jnosql-mapping-validation/src/test/java/org/eclipse/jnosql/mapping/validation/Computer.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-mapping-validation/src/test/java/org/eclipse/jnosql/mapping/validation/ConstructorValidationTest.java
+++ b/jnosql-mapping-validation/src/test/java/org/eclipse/jnosql/mapping/validation/ConstructorValidationTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-mapping-validation/src/test/java/org/eclipse/jnosql/mapping/validation/DatabaseMockProducer.java
+++ b/jnosql-mapping-validation/src/test/java/org/eclipse/jnosql/mapping/validation/DatabaseMockProducer.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-mapping-validation/src/test/java/org/eclipse/jnosql/mapping/validation/DocumentTemplateValidationTest.java
+++ b/jnosql-mapping-validation/src/test/java/org/eclipse/jnosql/mapping/validation/DocumentTemplateValidationTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-mapping-validation/src/test/java/org/eclipse/jnosql/mapping/validation/KeyValueTemplateValidationTest.java
+++ b/jnosql-mapping-validation/src/test/java/org/eclipse/jnosql/mapping/validation/KeyValueTemplateValidationTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-mapping-validation/src/test/java/org/eclipse/jnosql/mapping/validation/Person.java
+++ b/jnosql-mapping-validation/src/test/java/org/eclipse/jnosql/mapping/validation/Person.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-mapping-validation/src/test/java/org/eclipse/jnosql/mapping/validation/PersonBuilder.java
+++ b/jnosql-mapping-validation/src/test/java/org/eclipse/jnosql/mapping/validation/PersonBuilder.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-mapping-validation/src/test/java/org/eclipse/jnosql/mapping/validation/User.java
+++ b/jnosql-mapping-validation/src/test/java/org/eclipse/jnosql/mapping/validation/User.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-mapping-validation/src/test/resources/META-INF/beans.xml
+++ b/jnosql-mapping-validation/src/test/resources/META-INF/beans.xml
@@ -1,10 +1,10 @@
 <!--
   ~  Copyright (c) 2022 Contributors to the Eclipse Foundation
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-nosql-tck-runner/pom.xml
+++ b/jnosql-nosql-tck-runner/pom.xml
@@ -3,10 +3,10 @@
   ~
   ~  Copyright (c) 2024 Contributors to the Eclipse Foundation
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-nosql-tck-runner/src/test/java/org/eclipse/jnosql/tck/DocumentDatabase.java
+++ b/jnosql-nosql-tck-runner/src/test/java/org/eclipse/jnosql/tck/DocumentDatabase.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-nosql-tck-runner/src/test/java/org/eclipse/jnosql/tck/JNoSQLTemplateSupplier.java
+++ b/jnosql-nosql-tck-runner/src/test/java/org/eclipse/jnosql/tck/JNoSQLTemplateSupplier.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-nosql-tck-runner/src/test/resources/META-INF/microprofile-config.properties
+++ b/jnosql-nosql-tck-runner/src/test/resources/META-INF/microprofile-config.properties
@@ -1,10 +1,10 @@
 #
 # Copyright (c) 2022 Contributors to the Eclipse Foundation
 #  All rights reserved. This program and the accompanying materials
-#  are made available under the terms of the Eclipse Public License v1.0
+#  are made available under the terms of the Eclipse Public License 2.0
 #  and Apache License v2.0 which accompanies this distribution.
-#  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-#  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+#  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+#  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
 #
 # You may elect to redistribute this code under either of these licenses.
 #

--- a/jnosql-static-metamodel/jnosql-metamodel-processor/pom.xml
+++ b/jnosql-static-metamodel/jnosql-metamodel-processor/pom.xml
@@ -1,10 +1,10 @@
 <!--
   ~  Copyright (c) 2017 Otávio Santana and others
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-static-metamodel/jnosql-metamodel-processor/src/main/java/org/eclipse/jnosql/metamodel/processor/BaseMappingModel.java
+++ b/jnosql-static-metamodel/jnosql-metamodel-processor/src/main/java/org/eclipse/jnosql/metamodel/processor/BaseMappingModel.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-static-metamodel/jnosql-metamodel-processor/src/main/java/org/eclipse/jnosql/metamodel/processor/ClassAnalyzer.java
+++ b/jnosql-static-metamodel/jnosql-metamodel-processor/src/main/java/org/eclipse/jnosql/metamodel/processor/ClassAnalyzer.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-static-metamodel/jnosql-metamodel-processor/src/main/java/org/eclipse/jnosql/metamodel/processor/EntityModel.java
+++ b/jnosql-static-metamodel/jnosql-metamodel-processor/src/main/java/org/eclipse/jnosql/metamodel/processor/EntityModel.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-static-metamodel/jnosql-metamodel-processor/src/main/java/org/eclipse/jnosql/metamodel/processor/EntityProcessor.java
+++ b/jnosql-static-metamodel/jnosql-metamodel-processor/src/main/java/org/eclipse/jnosql/metamodel/processor/EntityProcessor.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-static-metamodel/jnosql-metamodel-processor/src/main/java/org/eclipse/jnosql/metamodel/processor/FieldAnalyzer.java
+++ b/jnosql-static-metamodel/jnosql-metamodel-processor/src/main/java/org/eclipse/jnosql/metamodel/processor/FieldAnalyzer.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-static-metamodel/jnosql-metamodel-processor/src/main/java/org/eclipse/jnosql/metamodel/processor/FieldModel.java
+++ b/jnosql-static-metamodel/jnosql-metamodel-processor/src/main/java/org/eclipse/jnosql/metamodel/processor/FieldModel.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-static-metamodel/jnosql-metamodel-processor/src/main/java/org/eclipse/jnosql/metamodel/processor/ProcessorUtil.java
+++ b/jnosql-static-metamodel/jnosql-metamodel-processor/src/main/java/org/eclipse/jnosql/metamodel/processor/ProcessorUtil.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-static-metamodel/jnosql-metamodel-processor/src/main/java/org/eclipse/jnosql/metamodel/processor/ValidationException.java
+++ b/jnosql-static-metamodel/jnosql-metamodel-processor/src/main/java/org/eclipse/jnosql/metamodel/processor/ValidationException.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-static-metamodel/jnosql-metamodel-processor/src/main/resources/metamodel.mustache
+++ b/jnosql-static-metamodel/jnosql-metamodel-processor/src/main/resources/metamodel.mustache
@@ -1,10 +1,10 @@
 /*
 *  Copyright (c) 2023 Otávio Santana and others
 *   All rights reserved. This program and the accompanying materials
-*   are made available under the terms of the Eclipse Public License v1.0
+*   are made available under the terms of the Eclipse Public License 2.0
 *   and Apache License v2.0 which accompanies this distribution.
-*   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-*   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+*   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+*   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
 *
 *   You may elect to redistribute this code under either of these licenses.
 *

--- a/jnosql-static-metamodel/jnosql-metamodel-sample/pom.xml
+++ b/jnosql-static-metamodel/jnosql-metamodel-sample/pom.xml
@@ -1,10 +1,10 @@
 <!--
   ~  Copyright (c) 2017 Otávio Santana and others
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-static-metamodel/jnosql-metamodel-sample/src/main/java/org/eclipse/jnsoql/entities/Car.java
+++ b/jnosql-static-metamodel/jnosql-metamodel-sample/src/main/java/org/eclipse/jnsoql/entities/Car.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-static-metamodel/jnosql-metamodel-sample/src/main/java/org/eclipse/jnsoql/entities/Checkout.java
+++ b/jnosql-static-metamodel/jnosql-metamodel-sample/src/main/java/org/eclipse/jnsoql/entities/Checkout.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-static-metamodel/jnosql-metamodel-sample/src/main/java/org/eclipse/jnsoql/entities/Fruit.java
+++ b/jnosql-static-metamodel/jnosql-metamodel-sample/src/main/java/org/eclipse/jnsoql/entities/Fruit.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-static-metamodel/jnosql-metamodel-sample/src/main/java/org/eclipse/jnsoql/entities/Person.java
+++ b/jnosql-static-metamodel/jnosql-metamodel-sample/src/main/java/org/eclipse/jnsoql/entities/Person.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-static-metamodel/jnosql-metamodel-sample/src/main/java/org/eclipse/jnsoql/entities/Product.java
+++ b/jnosql-static-metamodel/jnosql-metamodel-sample/src/main/java/org/eclipse/jnsoql/entities/Product.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-static-metamodel/jnosql-metamodel-sample/src/test/java/org/eclipse/jnsoql/entities/CarTest.java
+++ b/jnosql-static-metamodel/jnosql-metamodel-sample/src/test/java/org/eclipse/jnsoql/entities/CarTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-static-metamodel/jnosql-metamodel-sample/src/test/java/org/eclipse/jnsoql/entities/CheckoutTest.java
+++ b/jnosql-static-metamodel/jnosql-metamodel-sample/src/test/java/org/eclipse/jnsoql/entities/CheckoutTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-static-metamodel/jnosql-metamodel-sample/src/test/java/org/eclipse/jnsoql/entities/FruitTest.java
+++ b/jnosql-static-metamodel/jnosql-metamodel-sample/src/test/java/org/eclipse/jnsoql/entities/FruitTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-static-metamodel/jnosql-metamodel-sample/src/test/java/org/eclipse/jnsoql/entities/PersonTest.java
+++ b/jnosql-static-metamodel/jnosql-metamodel-sample/src/test/java/org/eclipse/jnsoql/entities/PersonTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Otávio Santana and others
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-static-metamodel/pom.xml
+++ b/jnosql-static-metamodel/pom.xml
@@ -3,10 +3,10 @@
   ~
   ~  Copyright (c) 2017 Otávio Santana and others
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-tinkerpop-connections/pom.xml
+++ b/jnosql-tinkerpop-connections/pom.xml
@@ -2,10 +2,10 @@
 <!--
   ~  Copyright (c) 2022 Contributors to the Eclipse Foundation
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-tinkerpop-connections/src/main/java/org/eclipse/jnosql/mapping/tinkerpop/connections/ArangoDBGraphConfiguration.java
+++ b/jnosql-tinkerpop-connections/src/main/java/org/eclipse/jnosql/mapping/tinkerpop/connections/ArangoDBGraphConfiguration.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop-connections/src/main/java/org/eclipse/jnosql/mapping/tinkerpop/connections/ArangoDBGraphConfigurations.java
+++ b/jnosql-tinkerpop-connections/src/main/java/org/eclipse/jnosql/mapping/tinkerpop/connections/ArangoDBGraphConfigurations.java
@@ -2,8 +2,8 @@
  *  Copyright (c) 2022 Eclipse Contribuitor
  * All rights reserved. This program and the accompanying materials
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *    You may elect to redistribute this code under either of these licenses.
  */
 

--- a/jnosql-tinkerpop-connections/src/main/java/org/eclipse/jnosql/mapping/tinkerpop/connections/JanusGraphConfiguration.java
+++ b/jnosql-tinkerpop-connections/src/main/java/org/eclipse/jnosql/mapping/tinkerpop/connections/JanusGraphConfiguration.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop-connections/src/main/java/org/eclipse/jnosql/mapping/tinkerpop/connections/Neo4JEmbeddedGraphConfiguration.java
+++ b/jnosql-tinkerpop-connections/src/main/java/org/eclipse/jnosql/mapping/tinkerpop/connections/Neo4JEmbeddedGraphConfiguration.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop-connections/src/main/java/org/eclipse/jnosql/mapping/tinkerpop/connections/Neo4JGraphConfiguration.java
+++ b/jnosql-tinkerpop-connections/src/main/java/org/eclipse/jnosql/mapping/tinkerpop/connections/Neo4JGraphConfiguration.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop-connections/src/main/java/org/eclipse/jnosql/mapping/tinkerpop/connections/Neo4JGraphConfigurations.java
+++ b/jnosql-tinkerpop-connections/src/main/java/org/eclipse/jnosql/mapping/tinkerpop/connections/Neo4JGraphConfigurations.java
@@ -2,8 +2,8 @@
  *  Copyright (c) 2022 Eclipse Contribuitor
  * All rights reserved. This program and the accompanying materials
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *    You may elect to redistribute this code under either of these licenses.
  */
 

--- a/jnosql-tinkerpop-connections/src/main/java/org/eclipse/jnosql/mapping/tinkerpop/connections/TitanGraphConfiguration.java
+++ b/jnosql-tinkerpop-connections/src/main/java/org/eclipse/jnosql/mapping/tinkerpop/connections/TitanGraphConfiguration.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop-connections/src/main/java/org/eclipse/jnosql/mapping/tinkerpop/connections/package-info.java
+++ b/jnosql-tinkerpop-connections/src/main/java/org/eclipse/jnosql/mapping/tinkerpop/connections/package-info.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop-connections/src/test/resources/META-INF/beans.xml
+++ b/jnosql-tinkerpop-connections/src/test/resources/META-INF/beans.xml
@@ -1,10 +1,10 @@
 <!--
   ~  Copyright (c) 2022 Contributors to the Eclipse Foundation
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/pom.xml
+++ b/pom.xml
@@ -2,10 +2,10 @@
 <!--
   ~  Copyright (c) 2022,2025 Contributors to the Eclipse Foundation
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~


### PR DESCRIPTION
This pull request updates the project’s license references to use the latest URLs and version for the Eclipse Public License (EPL) and Apache License. All references to the Eclipse Public License v1.0 are replaced with v2.0, and outdated URLs are updated to their current locations. No functional code changes are included; this is a documentation and metadata update to ensure compliance and clarity.

**License and documentation updates:**

* Updated all copyright headers in Java source files and XML configuration files to reference the Eclipse Public License 2.0 (EPL-2.0) instead of v1.0, and replaced old URLs with the current ones for both EPL-2.0 and Apache License 2.0. [[1]](diffhunk://#diff-556bea72b3e7945f6295250897f4da2ee62876da56a6d324a47ddb8de55da9b2L4-R7) [[2]](diffhunk://#diff-7f25fec3702a0f73d62978939723d4e686b3de1c275771e708d2f70abda33c14L4-R7) [[3]](diffhunk://#diff-2e6d9602f97860f797974b83e80f98de4b71d634c957a3e0e81a89a234b3a848L4-R7) [[4]](diffhunk://#diff-3c99c2eef16c6c99b615b7b7240c506d36879899f517a5b6f63e05b15016d819L4-R7) [[5]](diffhunk://#diff-e93213c981b6baae0b9b4a96f71094e356d4ea8972782ee5c2d0d3901168e134L4-R7) [[6]](diffhunk://#diff-95270d1b664cfa59f1019ba10852acd9da317308142ebeced5276d816f8ea491L4-R7) [[7]](diffhunk://#diff-daeb11dfb86760a4f50bd21aae7e99272c7d01e95cbf26d01849dfe8714c6a20L4-R7) [[8]](diffhunk://#diff-148f95105eedf06bcb8cacc55a9a6b727f2723474ec37800ff79f9ebf58555b0L4-R7) [[9]](diffhunk://#diff-08fa776427de8fab032c78ab9d4845cbaf48ee2189b7c95cf131cf64854bb785L4-R7) [[10]](diffhunk://#diff-bb4b708c9b9fd35c8f6e2b5d1c9dc4989d2016ff9de75835e167793d4164d028L5-R8) [[11]](diffhunk://#diff-926bf00edbd1b7ca31d2aeca5e6642c91f99507c3a473e101a770c3a3bd5a63fL5-R8) [[12]](diffhunk://#diff-4afa75a24cb23d44642fe8c3fb7ef0caec8bf42d08fe5eaa6aa32226d381eef7L5-R8) [[13]](diffhunk://#diff-464e219d9aac759ce84a724a941a99c27577bdda1dae1c4e27582c897cf9faa7L5-R8) [[14]](diffhunk://#diff-142778c437e37991e37bbb2ccccaf28515e628c7800c7bc6b88e3995dda8663cL5-R8) [[15]](diffhunk://#diff-1d2087a61792d7f2b33d24fa8274d42cf0f9c678bf75de465e519a650fe6c270L5-R8)
* Updated license notices in `pom.xml` and other resource files to reference EPL-2.0 and the correct URLs for both EPL-2.0 and Apache License 2.0. [[1]](diffhunk://#diff-72be70ac94b01a22f0192470d335d9e18459664ce70f5c9d370cc979b8a76612L6-R9) [[2]](diffhunk://#diff-a036342e5c2755aa0fd2562a028161db5690d3a7517f37cbfb60b3a74aafdd77L6-R9) [[3]](diffhunk://#diff-eb5f8785fe11ea2b293ac23117199e050952bfafc6556478867705050f129da8L6-R9) [[4]](diffhunk://#diff-967574e47a06a93754dbf3ca9f98cd6f3cfe419d3c6e1b9c7e07fb11461edf7cL6-R9)
* Updated the main `LICENSE` file to use the new EPL-2.0 URL.

No code logic or behavior was changed; these updates are for legal and documentation accuracy.