### PR TITLE
chore: update parent version to 1.2.0-M2 in all pom.xml files

### DIFF
--- a/jnosql-data-tck-runner/pom.xml
+++ b/jnosql-data-tck-runner/pom.xml
@@ -24,7 +24,7 @@
 	<parent>
 		<groupId>org.eclipse.jnosql.mapping</groupId>
 		<artifactId>jnosql-mapping-extensions</artifactId>
-		<version>1.2.0-SNAPSHOT</version>
+		<version>1.2.0-M2</version>
 	</parent>
 
 	<artifactId>jnosql-data-tck-runner</artifactId>

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/pom.xml
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.mapping</groupId>
         <artifactId>jnosql-jakarta-persistence-parent</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.2.0-M2</version>
     </parent>
 
     <artifactId>jnosql-jakarta-persistence-data-tck-runner</artifactId>

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/pom.xml
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.mapping</groupId>
         <artifactId>jnosql-jakarta-persistence-parent</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.2.0-M2</version>
     </parent>
 
     <artifactId>jnosql-jakarta-persistence</artifactId>

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-scanner/pom.xml
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-scanner/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.mapping</groupId>
         <artifactId>jnosql-jakarta-persistence-parent</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.2.0-M2</version>
     </parent>
 
     <artifactId>jnosql-jakarta-persistence-scanner</artifactId>

--- a/jnosql-jakarta-persistence/pom.xml
+++ b/jnosql-jakarta-persistence/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.mapping</groupId>
         <artifactId>jnosql-mapping-extensions</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.2.0-M2</version>
     </parent>
 
     <artifactId>jnosql-jakarta-persistence-parent</artifactId>

--- a/jnosql-lite/mapping-lite-column-test/pom.xml
+++ b/jnosql-lite/mapping-lite-column-test/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.lite</groupId>
         <artifactId>jnosql-lite-parent</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.2.0-M2</version>
     </parent>
 
     <artifactId>mapping-lite-column-test</artifactId>

--- a/jnosql-lite/mapping-lite-core-test/pom.xml
+++ b/jnosql-lite/mapping-lite-core-test/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.lite</groupId>
         <artifactId>jnosql-lite-parent</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.2.0-M2</version>
     </parent>
 
     <artifactId>mapping-lite-core-test</artifactId>

--- a/jnosql-lite/mapping-lite-document-test/pom.xml
+++ b/jnosql-lite/mapping-lite-document-test/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.lite</groupId>
         <artifactId>jnosql-lite-parent</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.2.0-M2</version>
     </parent>
 
     <artifactId>mapping-lite-document-test</artifactId>

--- a/jnosql-lite/mapping-lite-graph-test/pom.xml
+++ b/jnosql-lite/mapping-lite-graph-test/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.lite</groupId>
         <artifactId>jnosql-lite-parent</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.2.0-M2</version>
     </parent>
 
     <artifactId>mapping-lite-graph-test</artifactId>

--- a/jnosql-lite/mapping-lite-key-value-test/pom.xml
+++ b/jnosql-lite/mapping-lite-key-value-test/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.lite</groupId>
         <artifactId>jnosql-lite-parent</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.2.0-M2</version>
     </parent>
 
     <artifactId>mapping-lite-key-value-test</artifactId>

--- a/jnosql-lite/mapping-lite-processor/pom.xml
+++ b/jnosql-lite/mapping-lite-processor/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.lite</groupId>
         <artifactId>jnosql-lite-parent</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.2.0-M2</version>
     </parent>
 
     <artifactId>mapping-lite-processor</artifactId>

--- a/jnosql-lite/pom.xml
+++ b/jnosql-lite/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.mapping</groupId>
         <artifactId>jnosql-mapping-extensions</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.2.0-M2</version>
     </parent>
 
     <groupId>org.eclipse.jnosql.lite</groupId>

--- a/jnosql-mapping-validation/pom.xml
+++ b/jnosql-mapping-validation/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.mapping</groupId>
         <artifactId>jnosql-mapping-extensions</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.2.0-M2</version>
     </parent>
 
     <artifactId>jnosql-mapping-validation</artifactId>

--- a/jnosql-nosql-tck-runner/pom.xml
+++ b/jnosql-nosql-tck-runner/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.mapping</groupId>
         <artifactId>jnosql-mapping-extensions</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.2.0-M2</version>
     </parent>
 
     <artifactId>jnosql-nosql-tck-runner</artifactId>

--- a/jnosql-static-metamodel/jnosql-metamodel-processor/pom.xml
+++ b/jnosql-static-metamodel/jnosql-metamodel-processor/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.metamodel</groupId>
         <artifactId>jnosql-static-metamodel-parent</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.2.0-M2</version>
     </parent>
 
     <artifactId>mapping-metamodel-processor</artifactId>

--- a/jnosql-static-metamodel/jnosql-metamodel-sample/pom.xml
+++ b/jnosql-static-metamodel/jnosql-metamodel-sample/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.metamodel</groupId>
         <artifactId>jnosql-static-metamodel-parent</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.2.0-M2</version>
     </parent>
 
     <artifactId>mapping-lite-sample</artifactId>

--- a/jnosql-static-metamodel/pom.xml
+++ b/jnosql-static-metamodel/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.mapping</groupId>
         <artifactId>jnosql-mapping-extensions</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.2.0-M2</version>
     </parent>
 
     <groupId>org.eclipse.jnosql.metamodel</groupId>

--- a/jnosql-tinkerpop-connections/pom.xml
+++ b/jnosql-tinkerpop-connections/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.mapping</groupId>
         <artifactId>jnosql-mapping-extensions</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.2.0-M2</version>
     </parent>
 
     <artifactId>jnosql-tinkerpop-connections</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.mapping</groupId>
         <artifactId>jnosql-mapping-parent</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.2.0-M2</version>
     </parent>
 
     <artifactId>jnosql-mapping-extensions</artifactId>


### PR DESCRIPTION
This pull request updates the parent POM versions across multiple modules in the project from `1.2.0-SNAPSHOT` to the milestone release `1.2.0-M2`. This ensures that all submodules consistently use the latest milestone version of their parent dependencies, which can improve build stability and compatibility.

Dependency version updates:

* Updated parent POM version to `1.2.0-M2` in the following modules:
  - `jnosql-data-tck-runner/pom.xml`
  - `jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/pom.xml`
  - `jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/pom.xml`
  - `jnosql-jakarta-persistence/jnosql-jakarta-persistence-scanner/pom.xml`
  - `jnosql-jakarta-persistence/pom.xml`
  - `jnosql-lite/mapping-lite-column-test/pom.xml`
  - `jnosql-lite/mapping-lite-core-test/pom.xml`
  - `jnosql-lite/mapping-lite-document-test/pom.xml`
  - `jnosql-lite/mapping-lite-graph-test/pom.xml`
  - `jnosql-lite/mapping-lite-key-value-test/pom.xml`
  - `jnosql-lite/mapping-lite-processor/pom.xml`
  - `jnosql-lite/pom.xml`
  - `jnosql-mapping-validation/pom.xml`
  - `jnosql-nosql-tck-runner/pom.xml`
  - `jnosql-static-metamodel/jnosql-metamodel-processor/pom.xml`
  - `jnosql-static-metamodel/jnosql-metamodel-sample/pom.xml`
  - `jnosql-static-metamodel/pom.xml`
  - `jnosql-tinkerpop-connections/pom.xml`
  - `pom.xml`

No other functional or code changes were made; this is a straightforward dependency alignment across the project.