### PR TITLE
feat: add support for time-series databases in JNoSQL Lite

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -8,6 +8,10 @@ and this project adheres to https://semver.org/spec/v2.0.0.html[Semantic Version
 
 == [Unreleased]
 
+=== Added
+
+- Add support for time-series databases in JNoSQL Lite.
+
 == [1.1.16] - 2026-08-10
 
 == [1.1.15] - 2026-07-03

--- a/README.adoc
+++ b/README.adoc
@@ -23,6 +23,9 @@ Adopting the extension approach provides several benefits:
 
 - **Enhanced Maintainability:** Java Annotation Processors simplify codebase maintenance and debugging by replacing reflection-based operations with compile-time checks and optimizations.
 
+JNoSQL Lite supports key-value, document, column, graph, and time-series databases.
+The annotation processor detects the corresponding JNoSQL Mapping module on the classpath and generates repositories for that database type.
+
 === Extension Steps
 
 To use this Extension, follow a two-step process:
@@ -392,5 +395,4 @@ We are very happy you are interested in helping us and there are plenty ways you
 - https://github.com/eclipse/jnosql/issues[**Open an Issue:**]  Recommend improvements, changes and report bugs. Please, mention that the issue refers to the JNoSQL extensions project.
 
 - **Open a Pull Request:** If you feel like you can even make changes to our source code and suggest them, just check out our link:CONTRIBUTING.adoc[contributing guide] to learn about the development process, how to suggest bugfixes and improvements.
-
 

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/DatabaseSupport.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/DatabaseSupport.java
@@ -25,6 +25,7 @@ import java.util.stream.Collectors;
 enum DatabaseSupport {
 
     DOCUMENT("org.eclipse.jnosql.mapping.document.DocumentTemplate", DatabaseType.DOCUMENT),
+    TIME_SERIES("org.eclipse.jnosql.mapping.timeseries.TimeSeriesTemplate", DatabaseType.TIME_SERIES),
     COLUMN("org.eclipse.jnosql.mapping.column.ColumnTemplate", DatabaseType.COLUMN),
     KEY_VALUE("org.eclipse.jnosql.mapping.keyvalue.KeyValueTemplate", DatabaseType.KEY_VALUE),
     GRAPH("org.eclipse.jnosql.mapping.graph.GraphTemplate", DatabaseType.GRAPH);

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/RepositoryElement.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/RepositoryElement.java
@@ -72,6 +72,7 @@ class RepositoryElement {
     public RepositoryMetadata getMetadata(DatabaseType type) {
         return switch (type) {
             case DOCUMENT -> new SemiStructureRepositoryMetadata(this, "Document");
+            case TIME_SERIES -> new SemiStructureRepositoryMetadata(this, "TimeSeries");
             case COLUMN -> new SemiStructureRepositoryMetadata(this, "Column");
             case GRAPH -> new SemiStructureRepositoryMetadata(this, "Graph");
             case KEY_VALUE -> new KeyValueRepositoryMetadata(this);

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/SemiStructureRepositoryMetadata.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/SemiStructureRepositoryMetadata.java
@@ -14,14 +14,12 @@
  */
 package org.eclipse.jnosql.lite.mapping.repository;
 
-import java.util.Locale;
-
 class SemiStructureRepositoryMetadata extends RepositoryMetadata {
 
     private final String provider;
 
     SemiStructureRepositoryMetadata(RepositoryElement element, String provider) {
-        super(element, provider.toUpperCase(Locale.ENGLISH));
+        super(element, element.getType().name());
         this.provider = provider;
     }
 

--- a/jnosql-lite/mapping-lite-timeseries-test/.gitignore
+++ b/jnosql-lite/mapping-lite-timeseries-test/.gitignore
@@ -1,0 +1,15 @@
+target/
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+pom.xml.next
+test-output/
+/doc
+*.iml
+*.log
+.classpath
+-project
+/.resourceCache
+/.project
+/.idea
+.settings/

--- a/jnosql-lite/mapping-lite-timeseries-test/pom.xml
+++ b/jnosql-lite/mapping-lite-timeseries-test/pom.xml
@@ -1,0 +1,49 @@
+<!--
+  ~  Copyright (c) 2026 Contributors to the Eclipse Foundation
+  ~   All rights reserved. This program and the accompanying materials
+  ~   are made available under the terms of the Eclipse Public License 2.0
+  ~   and Apache License v2.0 which accompanies this distribution.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
+  ~
+  ~   You may elect to redistribute this code under either of these licenses.
+  ~
+  ~   Contributors:
+  ~
+  ~   Otavio Santana
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.eclipse.jnosql.lite</groupId>
+        <artifactId>jnosql-lite-parent</artifactId>
+        <version>1.1.18-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>mapping-lite-timeseries-test</artifactId>
+    <name>JNoSQL Lite Time Series Test</name>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.jnosql.mapping</groupId>
+            <artifactId>jnosql-mapping-timeseries</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.eclipse.jnosql.mapping</groupId>
+                    <artifactId>jnosql-mapping-reflection</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jnosql.lite</groupId>
+            <artifactId>mapping-lite-processor</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/jnosql-lite/mapping-lite-timeseries-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Measurement.java
+++ b/jnosql-lite/mapping-lite-timeseries-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/Measurement.java
@@ -1,0 +1,58 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License 2.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ */
+package org.eclipse.jnosql.lite.mapping.entities;
+
+import jakarta.nosql.Column;
+import jakarta.nosql.Entity;
+import jakarta.nosql.Id;
+
+import java.time.Instant;
+
+@Entity
+public class Measurement {
+
+    @Id
+    private Instant id;
+
+    @Column
+    private Instant timestamp;
+
+    @Column
+    private double value;
+
+    public Instant getId() {
+        return id;
+    }
+
+    public void setId(Instant id) {
+        this.id = id;
+    }
+
+    public Instant getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(Instant timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public double getValue() {
+        return value;
+    }
+
+    public void setValue(double value) {
+        this.value = value;
+    }
+}

--- a/jnosql-lite/mapping-lite-timeseries-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/MeasurementRepository.java
+++ b/jnosql-lite/mapping-lite-timeseries-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/MeasurementRepository.java
@@ -1,0 +1,27 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License 2.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ */
+package org.eclipse.jnosql.lite.mapping.entities;
+
+import jakarta.data.repository.Repository;
+import org.eclipse.jnosql.mapping.NoSQLRepository;
+
+import java.time.Instant;
+import java.util.List;
+
+@Repository
+public interface MeasurementRepository extends NoSQLRepository<Measurement, Instant> {
+
+    List<Measurement> findByTimestamp(Instant timestamp);
+}

--- a/jnosql-lite/mapping-lite-timeseries-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/MeasurementRepositoryTest.java
+++ b/jnosql-lite/mapping-lite-timeseries-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/MeasurementRepositoryTest.java
@@ -1,0 +1,87 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License 2.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ */
+package org.eclipse.jnosql.lite.mapping.entities;
+
+import org.assertj.core.api.SoftAssertions;
+import org.eclipse.jnosql.communication.Condition;
+import org.eclipse.jnosql.communication.semistructured.CriteriaCondition;
+import org.eclipse.jnosql.communication.semistructured.SelectQuery;
+import org.eclipse.jnosql.mapping.timeseries.TimeSeriesTemplate;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MeasurementRepositoryTest {
+
+    @Mock
+    private TimeSeriesTemplate template;
+
+    @InjectMocks
+    private MeasurementRepositoryLiteTimeSeries repository;
+
+    @Test
+    void shouldSaveMeasurement() {
+        Measurement measurement = new Measurement();
+        when(template.insert(measurement)).thenReturn(measurement);
+
+        Measurement result = repository.save(measurement);
+
+        assertThat(result).isSameAs(measurement);
+        verify(template).insert(measurement);
+    }
+
+    @Test
+    void shouldFindMeasurementById() {
+        Instant id = Instant.parse("2026-09-10T13:00:00Z");
+        Measurement measurement = new Measurement();
+        when(template.find(Measurement.class, id)).thenReturn(Optional.of(measurement));
+
+        Optional<Measurement> result = repository.findById(id);
+
+        assertThat(result).contains(measurement);
+        verify(template).find(Measurement.class, id);
+    }
+
+    @Test
+    void shouldFindMeasurementByTimestamp() {
+        Instant timestamp = Instant.parse("2026-09-10T13:00:00Z");
+        when(template.select(any(SelectQuery.class))).thenReturn(Stream.of(new Measurement()));
+
+        List<Measurement> result = repository.findByTimestamp(timestamp);
+
+        assertThat(result).hasSize(1);
+        ArgumentCaptor<SelectQuery> captor = ArgumentCaptor.forClass(SelectQuery.class);
+        verify(template).select(captor.capture());
+        CriteriaCondition condition = captor.getValue().condition().orElseThrow();
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(condition.condition()).isEqualTo(Condition.EQUALS);
+            soft.assertThat(condition.element().get(Instant.class)).isEqualTo(timestamp);
+        });
+    }
+}

--- a/jnosql-lite/pom.xml
+++ b/jnosql-lite/pom.xml
@@ -45,6 +45,7 @@
         <module>mapping-lite-key-value-test</module>
         <module>mapping-lite-core-test</module>
         <module>mapping-lite-document-test</module>
+        <module>mapping-lite-timeseries-test</module>
         <module>mapping-lite-column-test</module>
         <module>mapping-lite-graph-test</module>
     </modules>


### PR DESCRIPTION
This pull request adds support for time-series databases in JNoSQL Lite, extending the mapping-lite-processor and providing a new test module to validate this functionality. The changes include updates to documentation, core processor logic, and the addition of a new test suite for time-series support.

**Time-series database support:**

* Added `TIME_SERIES` as a supported database type in the `DatabaseSupport` enum, enabling the processor to recognize and handle time-series repositories.
* Updated `RepositoryElement#getMetadata` to return the correct metadata for time-series repositories, ensuring proper repository code generation.
* Modified `SemiStructureRepositoryMetadata` to use the database type name directly, supporting the new time-series type.

**Documentation updates:**

* Updated the `README.adoc` to mention support for time-series databases and described how the annotation processor detects and generates repositories for all supported types.
* Added an entry to the `CHANGELOG.adoc` noting the addition of time-series database support.

**New test module for time-series:**

* Added a new Maven module, `mapping-lite-timeseries-test`, including its `pom.xml` and `.gitignore`. This module contains an entity (`Measurement.java`), a repository interface (`MeasurementRepository.java`), and a test class (`MeasurementRepositoryTest.java`) to verify time-series repository behavior. [[1]](diffhunk://#diff-bfd7e1226715a807302f90eeaf5a4a772888ee4af5b00d7fe89309044766c474R1-R49) [[2]](diffhunk://#diff-999917c8a3e0caf6a983e0753cac555f6582ed3f5cd7119345a1a3d9f0ca1e12R1-R15) [[3]](diffhunk://#diff-06989db80a78f6270d957a9b82693c3eb9b4cb56abf5a92a9cfc50c360060f70R1-R58) [[4]](diffhunk://#diff-7887ee746acd2c25aaef415924cc03b8265589b1f9b6740523bd3ef99a32e87eR1-R27) [[5]](diffhunk://#diff-2ff55383b8ca006b1e34ff9dcdf33460c61b472431941849219c92535b54531bR1-R87) [[6]](diffhunk://#diff-16e0f57c71af53e62c663368df65e8a734958870ddcd88c494ffbdb783da2d76R48)