### PR TITLE
fix: Jakarta Persistence Driver - equality on values without natural ordering

### DIFF
--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/BaseQueryParser.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/BaseQueryParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2024,2026 Contributors to the Eclipse Foundation
  *
  *  All rights reserved. This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -173,9 +173,14 @@ abstract class BaseQueryParser {
         Element element = (Element) criteria.element();
         if (element.value().isNull()) {
             return ctx.builder().isNull(ctx.root().get(getName(element)));
-        } else {
-            ComparableContext comparableContext = ComparableContext.from(ctx, criteria, ignoreCase);
+        } else if (ignoreCase) {
+            // IgnoreCase is only defined for String values, which are Comparable
+            ComparableContext comparableContext = ComparableContext.from(ctx, criteria, true);
             return ctx.builder().equal(comparableContext.field(), comparableContext.expression());
+        } else {
+            // Equality imposes no ordering, so the value doesn't have to be Comparable
+            EqualityContext equalityContext = EqualityContext.from(ctx, criteria);
+            return ctx.builder().equal(equalityContext.field(), equalityContext.expression());
         }
     }
 
@@ -243,6 +248,19 @@ abstract class BaseQueryParser {
         }
     }
 
+    static Expression<?> getEqualityExpression(CriteriaBuilder cb, Object value) {
+        if (value instanceof ParamValue param && param.isEmpty()) {
+            // We only create parameter if we have no value
+            // If we have the value, we use the value instead
+            return cb.parameter(Object.class, param.getName());
+        } else if (value instanceof Value unwrapped) {
+            // Unlike Value.get(Class), Value.get() doesn't require a ValueReader for the target type
+            return cb.literal(unwrapped.get());
+        } else {
+            return cb.literal(value);
+        }
+    }
+
     @SafeVarargs
     static void requireComparisonSupportsIgnoreCase(CriteriaCondition criteria, Expression<? extends Comparable>... operands) {
             if (!Stream.of(operands).allMatch(BaseQueryParser::isStringExpression)) {
@@ -277,6 +295,15 @@ abstract class BaseQueryParser {
                 expression = ctx.builder().upper((Expression<String>) expression);
             }
             return new ComparableContext(field, expression);
+        }
+    }
+
+    static record EqualityContext(Expression<?> field, Expression<?> expression) {
+
+        public static <FROM> EqualityContext from(QueryContext<FROM> ctx, CriteriaCondition criteria) {
+            Element element = (Element) criteria.element();
+            return new EqualityContext(ctx.root().get(getName(element)),
+                    getEqualityExpression(ctx.builder(), element.value()));
         }
     }
 

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/Person.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/Person.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2024,2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
  *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
@@ -15,6 +15,7 @@
 package ee.omnifish.jnosql.jakartapersistence;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
@@ -38,6 +39,9 @@ public class Person {
 
     @Column
     private List<String> phones;
+
+    @Embedded
+    private SocialSecurityNumber ssn;
 
     public long getId() {
         return id;
@@ -69,6 +73,14 @@ public class Person {
 
     public void setAge(long age) {
         this.age = age;
+    }
+
+    public SocialSecurityNumber getSsn() {
+        return ssn;
+    }
+
+    public void setSsn(SocialSecurityNumber ssn) {
+        this.ssn = ssn;
     }
 
 

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/PersonRepository.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/PersonRepository.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2024,2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
  *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
@@ -14,7 +14,9 @@
  */
 package ee.omnifish.jnosql.jakartapersistence;
 
+import jakarta.data.repository.By;
 import jakarta.data.repository.CrudRepository;
+import jakarta.data.repository.Find;
 import jakarta.data.repository.Repository;
 import java.util.List;
 import java.util.Set;
@@ -26,5 +28,9 @@ public interface PersonRepository extends CrudRepository<Person, String> {
     List<Person> findByNameAndAgeLessThanEqual(String name, long age);
     List<Person> findByNameIn(Set<String> names);
     List<Person> findByNameIgnoreCaseNot(String name);
+    List<Person> findBySsn(SocialSecurityNumber ssn);
+
+    @Find
+    List<Person> personsBySsn(@By("ssn") SocialSecurityNumber ssn);
 }
 

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/PersonRepositoryTest.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/PersonRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2024,2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
  *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
@@ -116,6 +116,28 @@ public class PersonRepositoryTest {
     }
 
     @Test
+    void findByEmbeddableWithoutNaturalOrdering() {
+        final SocialSecurityNumber ssn = new SocialSecurityNumber("123-45-6789");
+        new PersonBuilder().name("Jakarta").ssn(ssn).insert(personRepo);
+        new PersonBuilder().name("Data").ssn(new SocialSecurityNumber("987-65-4321")).insert(personRepo);
+
+        final List<Person> persons = personRepo.findBySsn(ssn);
+        assertThat(persons, hasSize(1));
+        assertThat(persons.get(0).getName(), is("Jakarta"));
+    }
+
+    @Test
+    void findAnnotatedByEmbeddableWithoutNaturalOrdering() {
+        final SocialSecurityNumber ssn = new SocialSecurityNumber("123-45-6789");
+        new PersonBuilder().name("Jakarta").ssn(ssn).insert(personRepo);
+        new PersonBuilder().name("Data").ssn(new SocialSecurityNumber("987-65-4321")).insert(personRepo);
+
+        final List<Person> persons = personRepo.personsBySsn(ssn);
+        assertThat(persons, hasSize(1));
+        assertThat(persons.get(0).getName(), is("Jakarta"));
+    }
+
+    @Test
     void hermesParser() {
         getEntityManager().createQuery("UPDATE Person SET age = age + 1");
     }
@@ -131,6 +153,11 @@ public class PersonRepositoryTest {
 
         public PersonBuilder age(long age) {
             p.setAge(age);
+            return this;
+        }
+
+        public PersonBuilder ssn(SocialSecurityNumber ssn) {
+            p.setSsn(ssn);
             return this;
         }
 

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/PersonRepositoryTest.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/PersonRepositoryTest.java
@@ -16,6 +16,10 @@ package ee.omnifish.jnosql.jakartapersistence;
 
 import jakarta.enterprise.inject.se.SeContainer;
 import jakarta.persistence.EntityManager;
+import org.eclipse.jnosql.communication.semistructured.DeleteQuery;
+import org.eclipse.jnosql.communication.semistructured.SelectQuery;
+import org.eclipse.jnosql.jakartapersistence.communication.PersistenceDatabaseManagerProvider;
+import org.eclipse.jnosql.jakartapersistence.mapping.PersistenceDocumentTemplate;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -53,6 +57,12 @@ public class PersonRepositoryTest {
 
     private EntityManager getEntityManager() {
         return cdiContainer.select(EntityManager.class).get();
+    }
+
+    private PersistenceDocumentTemplate getTemplate() {
+        // Created the same way as in PersistenceRepositoryProducer
+        return new PersistenceDocumentTemplate(
+                cdiContainer.select(PersistenceDatabaseManagerProvider.class).get().getManager(getEntityManager()));
     }
 
     @AfterEach
@@ -135,6 +145,33 @@ public class PersonRepositoryTest {
         final List<Person> persons = personRepo.personsBySsn(ssn);
         assertThat(persons, hasSize(1));
         assertThat(persons.get(0).getName(), is("Jakarta"));
+    }
+
+    @Test
+    void selectQueryByEmbeddableWithoutNaturalOrdering() {
+        final SocialSecurityNumber ssn = new SocialSecurityNumber("123-45-6789");
+        new PersonBuilder().name("Jakarta").ssn(ssn).insert(personRepo);
+        new PersonBuilder().name("Data").ssn(new SocialSecurityNumber("987-65-4321")).insert(personRepo);
+
+        // Unlike repository methods, a SelectQuery carries the operand as a resolved Value, not a ParamValue
+        final SelectQuery query = SelectQuery.select().from("Person").where("ssn").eq(ssn).build();
+        final List<Person> persons = getTemplate().<Person>select(query).toList();
+        assertThat(persons, hasSize(1));
+        assertThat(persons.get(0).getName(), is("Jakarta"));
+    }
+
+    @Test
+    void deleteQueryByEmbeddableWithoutNaturalOrdering() {
+        final SocialSecurityNumber ssn = new SocialSecurityNumber("123-45-6789");
+        new PersonBuilder().name("Jakarta").ssn(ssn).insert(personRepo);
+        new PersonBuilder().name("Data").ssn(new SocialSecurityNumber("987-65-4321")).insert(personRepo);
+
+        final DeleteQuery query = DeleteQuery.delete().from("Person").where("ssn").eq(ssn).build();
+        getTemplate().delete(query);
+
+        final List<Person> persons = personRepo.findAll().toList();
+        assertThat(persons, hasSize(1));
+        assertThat(persons.get(0).getName(), is("Data"));
     }
 
     @Test

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/SocialSecurityNumber.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/SocialSecurityNumber.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License 2.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ *
+ *  Contributors:
+ *
+ *  Renat R. Safiullin
+ */
+package ee.omnifish.jnosql.jakartapersistence;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/**
+ * An embeddable value type that deliberately does not implement {@link Comparable},
+ * to cover equality comparisons against values with no natural ordering.
+ */
+@Embeddable
+public class SocialSecurityNumber implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @Column(name = "SSN")
+    private String number;
+
+    public SocialSecurityNumber() {
+    }
+
+    public SocialSecurityNumber(String number) {
+        this.number = Objects.requireNonNull(number, "number is required");
+    }
+
+    public String getNumber() {
+        return number;
+    }
+
+    public void setNumber(String number) {
+        this.number = number;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof SocialSecurityNumber other)) {
+            return false;
+        }
+        return Objects.equals(number, other.number);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(number);
+    }
+
+    @Override
+    public String toString() {
+        return "SocialSecurityNumber{" + number + '}';
+    }
+}

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/resources/META-INF/persistence.xml
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/resources/META-INF/persistence.xml
@@ -19,6 +19,7 @@
   <persistence-unit name="testPersistenceUnit" transaction-type="RESOURCE_LOCAL">
     <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
     <class>ee.omnifish.jnosql.jakartapersistence.Person</class>
+    <class>ee.omnifish.jnosql.jakartapersistence.SocialSecurityNumber</class>
     <class>org.eclipse.jnosql.extensions.sql.model.Computer</class>
     <exclude-unlisted-classes>true</exclude-unlisted-classes>
     <properties>


### PR DESCRIPTION
Fixes eclipse-jnosql/jnosql#785

### Problem

`BaseQueryParser.parseEquals` routed every non-null equality through `ComparableContext`, which resolves the operand with `Value.get(Comparable.class)`. That call goes through `ValueReaderDecorator.read`, which returns the value only if it already is a `Comparable` and otherwise looks for a `ValueReader` for `Comparable`. No such reader exists, so any equality against a value with no natural ordering failed with:

```
java.lang.UnsupportedOperationException: The type interface java.lang.Comparable is not supported yet
	at org.eclipse.jnosql.communication.ValueReaderDecorator.read(ValueReaderDecorator.java:60)
	at org.eclipse.jnosql.communication.DefaultValue.get(DefaultValue.java:48)
	at org.eclipse.jnosql.jakartapersistence.mapping.BaseQueryParser.getComparableExpression(BaseQueryParser.java:256)
	at org.eclipse.jnosql.jakartapersistence.mapping.BaseQueryParser$ComparableContext.from(BaseQueryParser.java:286)
	at org.eclipse.jnosql.jakartapersistence.mapping.BaseQueryParser.parseEquals(BaseQueryParser.java:191)
```

The usual trigger is a repository method that queries by an `@Embeddable` domain identifier — `TrackingId`, `UnLocode`, `VoyageNumber` — which defines `equals`/`hashCode` but no ordering.

### Change

`CriteriaBuilder.equal` imposes no ordering requirement, so the `Comparable` constraint is only correct for `LESSER_THAN`, `LESSER_EQUALS_THAN`, `GREATER_THAN`, `GREATER_EQUALS_THAN` and `BETWEEN`. `parseEquals` gets an `Expression<?>`-typed operand path that unwraps with `Value.get()`, which needs no `ValueReader` — the same approach `parseIn` already takes in `MultiValueContext.from`. The ordering conditions and the `ignoreCase` variant, which is defined only for `String`, keep using `ComparableContext` unchanged.

### Tests

`Person` gains an embedded `SocialSecurityNumber`, an `@Embeddable` that deliberately does not implement `Comparable`, and `PersonRepositoryTest` queries it through both a derived method name and `@Find`:

```java
List<Person> findBySsn(SocialSecurityNumber ssn);

@Find
List<Person> personsBySsn(@By("ssn") SocialSecurityNumber ssn);
```

It also runs the same equality through `PersistenceDocumentTemplate` with a `SelectQuery` and a `DeleteQuery`:

```java
SelectQuery.select().from("Person").where("ssn").eq(ssn).build();
DeleteQuery.delete().from("Person").where("ssn").eq(ssn).build();
```

All four assert on the affected rows, so they cover the generated predicate and not just the absence of an exception.

On current `main` the two repository tests pass without the production change: `JakartaPersistenceParameterBasedQuery.toQuery` takes `Map<String, ParamValue>`, so the operand goes to the `cb.parameter(...)` branch. A `SelectQuery` or `DeleteQuery` still carries a resolved `Value`, and without the `BaseQueryParser` change both template tests fail on `main` with the exception above (`PersistenceDocumentTemplate.select` → `SelectQueryParser` → `QueryModifier.where` → `parseEquals`). With the change the full `jnosql-jakarta-persistence-driver` suite is green (269 tests, 0 failures, 5 skipped). Against 1.1.17 the two repository tests fail with the stack above, and the patch turns them green with no other change.

#223 adds the same `SocialSecurityNumber` fixture and repository tests to `main`; whichever lands second needs that part dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
