### PR TITLE
fix: Jakarta Persistence Driver - load a returned Page before the transaction ends

### DIFF
--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/repository/SqlInvocationHandler.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/repository/SqlInvocationHandler.java
@@ -15,6 +15,7 @@
  */
 package org.eclipse.jnosql.extensions.sql.repository;
 
+import jakarta.data.page.Page;
 import jakarta.nosql.Template;
 import jakarta.persistence.EntityManager;
 import org.eclipse.jnosql.extensions.sql.SqlEntityMetadata;
@@ -88,7 +89,20 @@ final class SqlInvocationHandler<T, K>  extends AbstractRepositoryInvocationHand
         if(method.getReturnType().equals(EntityManager.class)) {
             return this.template.entityManager();
         }
-        return super.invoke(proxy, method, params);
+        return loadTotalEagerly(super.invoke(proxy, method, params));
+    }
+
+    /**
+     * The total number of elements of a page is computed lazily, on the first call to
+     * {@link Page#totalElements()}. That call typically happens after the repository method
+     * returned, when the transaction is over and a container-managed EntityManager is already
+     * closed. Compute the total here instead, while the EntityManager is still open.
+     */
+    private Object loadTotalEagerly(Object result) {
+        if (result instanceof Page<?> page && page.pageRequest().requestTotal()) {
+            page.totalElements();
+        }
+        return result;
     }
 
 }

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/PageOutsideTransactionTest.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/PageOutsideTransactionTest.java
@@ -14,6 +14,7 @@ package ee.omnifish.jnosql.jakartapersistence;
 import jakarta.data.page.Page;
 import jakarta.data.page.PageRequest;
 import jakarta.enterprise.inject.se.SeContainer;
+import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -27,6 +28,7 @@ public class PageOutsideTransactionTest {
 
     private SeContainer cdiContainer;
     private PagePersonRepository repository;
+    private EntityManager entityManager;
 
     @BeforeEach
     void init() {
@@ -37,6 +39,7 @@ public class PageOutsideTransactionTest {
                 .initialize();
 
         repository = cdiContainer.select(PagePersonRepository.class).get();
+        entityManager = cdiContainer.select(EntityManager.class).get();
 
         repository.deleteAllPersons();
 
@@ -63,6 +66,43 @@ public class PageOutsideTransactionTest {
                         "Ali%",
                         PageRequest.ofPage(1).size(10));
 
+        assertThat(page.totalElements(), is(2L));
+    }
+
+    /**
+     * A container-managed EntityManager is closed when the transaction started by the repository
+     * method ends, so the page must be fully loaded by the time the method returns.
+     */
+    @Test
+    void pageAccessibleAfterEntityManagerIsClosed() {
+        Page<Person> page =
+                repository.findByNameLike(
+                        "Ali%",
+                        PageRequest.ofPage(1).size(10));
+
+        entityManager.close();
+
+        assertThat(page.content().size(), is(2));
+        assertThat(page.totalElements(), is(2L));
+    }
+
+    /**
+     * The same, but with the transaction owned by the caller, as with {@code @Transactional} on
+     * the repository. The repository method doesn't start the transaction, but it still ends
+     * before the page is read.
+     */
+    @Test
+    void pageAccessibleWhenCallerOwnsTheTransaction() {
+        entityManager.getTransaction().begin();
+        Page<Person> page =
+                repository.findByNameLike(
+                        "Ali%",
+                        PageRequest.ofPage(1).size(10));
+        entityManager.getTransaction().commit();
+
+        entityManager.close();
+
+        assertThat(page.content().size(), is(2));
         assertThat(page.totalElements(), is(2L));
     }
 }


### PR DESCRIPTION
Fixes https://github.com/eclipse-jnosql/jnosql/issues/786, reported downstream as eclipse-ee4j/glassfish#25941.

A `Page` returned from a repository method is loaded lazily. In a container the `EntityManager` is transaction-scoped and closed when the transaction ends, normally as the repository method returns, so reading the page afterwards fails with `Attempting to execute an operation on a closed EntityManager`.

### Change

`SqlInvocationHandler` — the content is already materialized on this path, but the total is not: `NoSQLPage` resolves it through a `LazyLongSupplier` that calls back into `DefaultSqlTemplate.count`, which then tries to begin a transaction on a closed `EntityManager`. It is now resolved before the repository method returns, and only when `PageRequest.requestTotal()` is set, so a page request that does not ask for totals costs no extra query.

On `main` this is the only repository path: `AbstractRepositoryPersistenceBean.create()` returns `SqlRepositoryProducer.get(...)` for both standard and custom repositories. `EnsureTransactionInterceptor`, which has the same defect, is reached only through `JakartaPersistenceRepositoryProxy`, and `createInvocationHandler`, which builds that proxy, has no callers. The interceptor is therefore left unchanged here.

### Tests

Two cases added to `PageOutsideTransactionTest`, one per transaction owner (the repository method, the caller), both closing the `EntityManager` to stand in for a container-managed transaction-scoped one. Both fail on `main` before this change. The existing test in that class does not catch the defect because the harness produces an `@ApplicationScoped` `EntityManager` that is never closed during a test, so a lazy page always finds a live one.

Full driver suite: 267 tests, 0 failures, 5 skipped (pre-existing `@Disabled`).

### Backport

GlassFish 8 pins 1.1.x (8.0.4 uses 1.1.15) and cannot move to 1.2.0-M2, which requires jakarta.data-api 1.1.0-M4, so the fix has to be backported for it to reach GlassFish. The repository path differs on 1.1.x: `RepositoryPersistenceBean` builds `JakartaPersistenceRepositoryProxy` directly, so `EnsureTransactionInterceptor` is live there and is where the fix goes. Its eager fetch has to apply also when the caller owns the transaction, and has to resolve the total as well. Verified against tag 1.1.15, where that change makes both new test cases pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
