### PR TITLE
Fix/785 non comparable equality

### DIFF
--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/BaseQueryParser.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/BaseQueryParser.java
@@ -187,9 +187,12 @@ abstract class BaseQueryParser {
         Element element = (Element) criteria.element();
         if (element.value().isNull()) {
             return ctx.builder().isNull(ctx.root().get(getName(element)));
-        } else {
-            ComparableContext comparableContext = ComparableContext.from(ctx, criteria, ignoreCase);
+        } else if (ignoreCase) {
+            ComparableContext comparableContext = ComparableContext.from(ctx, criteria, true);
             return ctx.builder().equal(comparableContext.field(), comparableContext.expression());
+        } else {
+            EqualityContext equalityContext = EqualityContext.from(ctx, criteria);
+            return ctx.builder().equal(equalityContext.field(), equalityContext.expression());
         }
     }
 
@@ -276,6 +279,24 @@ abstract class BaseQueryParser {
     }
 
     static record QueryContext<FROM>(Root<FROM> root, CriteriaBuilder builder) {
+    }
+
+    static record EqualityContext(Expression<?> field, Expression<?> expression) {
+
+        public static <FROM> EqualityContext from(QueryContext ctx, CriteriaCondition criteria) {
+            Element element = (Element) criteria.element();
+            Expression<?> field = ctx.root().get(getName(element));
+            Object value = element.value();
+            Expression<?> expression;
+            if (value instanceof ParamValue param && param.isEmpty()) {
+                expression = ctx.builder().parameter(field.getJavaType(), param.getName());
+            } else if (value instanceof Value wrappedValue) {
+                expression = ctx.builder().literal(wrappedValue.get());
+            } else {
+                expression = ctx.builder().literal(value);
+            }
+            return new EqualityContext(field, expression);
+        }
     }
 
     static record ComparableContext(Expression<? extends Comparable> field, Expression<? extends Comparable> expression) {

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/Person.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/Person.java
@@ -17,6 +17,7 @@ package ee.omnifish.jnosql.jakartapersistence;
 import static jakarta.persistence.GenerationType.AUTO;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
@@ -37,6 +38,9 @@ public class Person {
 
     @Column
     private List<String> phones;
+
+    @Embedded
+    private SocialSecurityNumber ssn;
 
     public long getId() {
         return id;
@@ -70,5 +74,12 @@ public class Person {
         this.age = age;
     }
 
+    public SocialSecurityNumber getSsn() {
+        return ssn;
+    }
+
+    public void setSsn(SocialSecurityNumber ssn) {
+        this.ssn = ssn;
+    }
 
 }

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/PersonRepository.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/PersonRepository.java
@@ -14,7 +14,9 @@
  */
 package ee.omnifish.jnosql.jakartapersistence;
 
+import jakarta.data.repository.By;
 import jakarta.data.repository.CrudRepository;
+import jakarta.data.repository.Find;
 import jakarta.data.repository.Repository;
 import java.util.List;
 import java.util.Set;
@@ -26,5 +28,8 @@ public interface PersonRepository extends CrudRepository<Person, String> {
     List<Person> findByNameAndAgeLessThanEqual(String name, long age);
     List<Person> findByNameIn(Set<String> names);
     List<Person> findByNameIgnoreCaseNot(String name);
-}
+    List<Person> findBySsn(SocialSecurityNumber ssn);
 
+    @Find
+    List<Person> personsBySsn(@By("ssn") SocialSecurityNumber ssn);
+}

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/PersonRepositoryTest.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/PersonRepositoryTest.java
@@ -152,6 +152,22 @@ public class PersonRepositoryTest {
     }
 
     @Test
+    void findByEmbeddedValue() {
+        SocialSecurityNumber ssn = new SocialSecurityNumber("123-45-6789");
+        new PersonBuilder().name("Jakarta").ssn(ssn).insert(personRepo);
+
+        assertThat(personRepo.findBySsn(ssn), hasSize(1));
+    }
+
+    @Test
+    void findByEmbeddedValueUsingFindAnnotation() {
+        SocialSecurityNumber ssn = new SocialSecurityNumber("123-45-6789");
+        new PersonBuilder().name("Jakarta").ssn(ssn).insert(personRepo);
+
+        assertThat(personRepo.personsBySsn(ssn), hasSize(1));
+    }
+
+    @Test
     void hermesParser() {
         getEntityManager().createQuery("UPDATE Person SET age = age + 1");
     }
@@ -167,6 +183,11 @@ public class PersonRepositoryTest {
 
         public PersonBuilder age(long age) {
             p.setAge(age);
+            return this;
+        }
+
+        public PersonBuilder ssn(SocialSecurityNumber ssn) {
+            p.setSsn(ssn);
             return this;
         }
 

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/SocialSecurityNumber.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/SocialSecurityNumber.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * and Apache License v2.0 which accompanies this distribution.
+ * The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ * and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package ee.omnifish.jnosql.jakartapersistence;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+@Embeddable
+public class SocialSecurityNumber implements Serializable {
+
+    @Column(name = "SSN")
+    private String number;
+
+    public SocialSecurityNumber() {
+    }
+
+    public SocialSecurityNumber(String number) {
+        this.number = number;
+    }
+
+    public String getNumber() {
+        return number;
+    }
+
+    public void setNumber(String number) {
+        this.number = number;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof SocialSecurityNumber other)) {
+            return false;
+        }
+        return Objects.equals(number, other.number);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(number);
+    }
+}


### PR DESCRIPTION
This pull request adds support for querying entities by embedded value objects in Jakarta Persistence, specifically by allowing repositories to find entities using embedded types such as `SocialSecurityNumber`. It introduces the necessary model, repository methods, and parsing logic to handle equality queries on embedded objects, and includes comprehensive tests for these new capabilities.

Key changes:

**Support for Embedded Value Querying:**

* Added a new `@Embeddable` class `SocialSecurityNumber` to represent an embedded value object, along with standard equals/hashCode implementations. (`SocialSecurityNumber.java`)
* Updated the `Person` entity to include an `@Embedded` field of type `SocialSecurityNumber`, with corresponding getter and setter methods. (`Person.java`) [[1]](diffhunk://#diff-9ebdbdb0a23b1b3b423d8cd0ccd9c3adf5b4c6acc075359946e513df3933d8aaR20) [[2]](diffhunk://#diff-9ebdbdb0a23b1b3b423d8cd0ccd9c3adf5b4c6acc075359946e513df3933d8aaR42-R44) [[3]](diffhunk://#diff-9ebdbdb0a23b1b3b423d8cd0ccd9c3adf5b4c6acc075359946e513df3933d8aaR77-R83)

**Repository Enhancements:**

* Added repository methods `findBySsn` and `personsBySsn` (with `@Find` and `@By`) to allow querying `Person` entities by their embedded `SocialSecurityNumber`. (`PersonRepository.java`) [[1]](diffhunk://#diff-66b2a1a41b7cc720a2efecfb494242c4ab3f9a4881dd5c89228d14ac5281fd58R17-R19) [[2]](diffhunk://#diff-66b2a1a41b7cc720a2efecfb494242c4ab3f9a4881dd5c89228d14ac5281fd58L29-R35)

**Query Parsing Improvements:**

* Refactored the query parser to support equality checks on embedded objects by introducing a new `EqualityContext` record and updating the `parseEquals` logic to use it when `ignoreCase` is false. (`BaseQueryParser.java`) [[1]](diffhunk://#diff-8223752fc9c938f27119e45f279d12c02316475f25e3121c8e552d895d873fd0L190-R195) [[2]](diffhunk://#diff-8223752fc9c938f27119e45f279d12c02316475f25e3121c8e552d895d873fd0R284-R301)

**Testing:**

* Added tests to verify querying by embedded value using both standard and annotation-driven repository methods, and extended the `PersonBuilder` to support setting the `ssn`. (`PersonRepositoryTest.java`) [[1]](diffhunk://#diff-b88a2cd88a6d0a06f87c8721879451be50ed188c64b7365ea275f89cbd1d3b91R154-R169) [[2]](diffhunk://#diff-b88a2cd88a6d0a06f87c8721879451be50ed188c64b7365ea275f89cbd1d3b91R189-R193)

These changes collectively enable and validate the ability to perform repository queries using embedded value objects as criteria, improving the expressiveness and utility of the persistence layer.