### PR TITLE
test: cover non-comparable embeddable equality

### DIFF
--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/Person.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/Person.java
@@ -15,6 +15,7 @@
 package ee.omnifish.jnosql.jakartapersistence;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
@@ -38,6 +39,9 @@ public class Person {
 
     @Column
     private List<String> phones;
+
+    @Embedded
+    private SocialSecurityNumber ssn;
 
     public long getId() {
         return id;
@@ -71,5 +75,12 @@ public class Person {
         this.age = age;
     }
 
+    public SocialSecurityNumber getSsn() {
+        return ssn;
+    }
+
+    public void setSsn(SocialSecurityNumber ssn) {
+        this.ssn = ssn;
+    }
 
 }

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/PersonRepository.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/PersonRepository.java
@@ -14,7 +14,9 @@
  */
 package ee.omnifish.jnosql.jakartapersistence;
 
+import jakarta.data.repository.By;
 import jakarta.data.repository.CrudRepository;
+import jakarta.data.repository.Find;
 import jakarta.data.repository.Repository;
 import java.util.List;
 import java.util.Set;
@@ -26,5 +28,8 @@ public interface PersonRepository extends CrudRepository<Person, String> {
     List<Person> findByNameAndAgeLessThanEqual(String name, long age);
     List<Person> findByNameIn(Set<String> names);
     List<Person> findByNameIgnoreCaseNot(String name);
-}
+    List<Person> findBySsn(SocialSecurityNumber ssn);
 
+    @Find
+    List<Person> personsBySsn(@By("ssn") SocialSecurityNumber ssn);
+}

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/PersonRepositoryTest.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/PersonRepositoryTest.java
@@ -116,6 +116,22 @@ public class PersonRepositoryTest {
     }
 
     @Test
+    void findByEmbeddedValue() {
+        SocialSecurityNumber ssn = new SocialSecurityNumber("123-45-6789");
+        new PersonBuilder().name("Jakarta").ssn(ssn).insert(personRepo);
+
+        assertThat(personRepo.findBySsn(ssn), hasSize(1));
+    }
+
+    @Test
+    void findByEmbeddedValueUsingFindAnnotation() {
+        SocialSecurityNumber ssn = new SocialSecurityNumber("123-45-6789");
+        new PersonBuilder().name("Jakarta").ssn(ssn).insert(personRepo);
+
+        assertThat(personRepo.personsBySsn(ssn), hasSize(1));
+    }
+
+    @Test
     void hermesParser() {
         getEntityManager().createQuery("UPDATE Person SET age = age + 1");
     }
@@ -131,6 +147,11 @@ public class PersonRepositoryTest {
 
         public PersonBuilder age(long age) {
             p.setAge(age);
+            return this;
+        }
+
+        public PersonBuilder ssn(SocialSecurityNumber ssn) {
+            p.setSsn(ssn);
             return this;
         }
 

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/SocialSecurityNumber.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/SocialSecurityNumber.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * and Apache License v2.0 which accompanies this distribution.
+ * The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ * and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package ee.omnifish.jnosql.jakartapersistence;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+@Embeddable
+public class SocialSecurityNumber implements Serializable {
+
+    @Column(name = "SSN")
+    private String number;
+
+    public SocialSecurityNumber() {
+    }
+
+    public SocialSecurityNumber(String number) {
+        this.number = number;
+    }
+
+    public String getNumber() {
+        return number;
+    }
+
+    public void setNumber(String number) {
+        this.number = number;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof SocialSecurityNumber other)) {
+            return false;
+        }
+        return Objects.equals(number, other.number);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(number);
+    }
+}


### PR DESCRIPTION
This pull request adds support for using embedded value objects in JPA entities and repositories, specifically by introducing a `SocialSecurityNumber` embedded type to the `Person` entity. It also updates the repository and test classes to demonstrate and verify querying by this embedded value. The main changes are grouped below:

### Support for Embedded Value Objects

* Introduced the `SocialSecurityNumber` class as an `@Embeddable` value object with appropriate equals and hashCode implementations. (`SocialSecurityNumber.java`)
* Updated the `Person` entity to include an `@Embedded` field for `SocialSecurityNumber` with getter and setter methods. (`Person.java`) [[1]](diffhunk://#diff-9ebdbdb0a23b1b3b423d8cd0ccd9c3adf5b4c6acc075359946e513df3933d8aaR18) [[2]](diffhunk://#diff-9ebdbdb0a23b1b3b423d8cd0ccd9c3adf5b4c6acc075359946e513df3933d8aaR43-R45) [[3]](diffhunk://#diff-9ebdbdb0a23b1b3b423d8cd0ccd9c3adf5b4c6acc075359946e513df3933d8aaR78-R84)

### Repository Enhancements

* Added repository methods to query `Person` entities by their embedded `ssn` field, including both convention-based and annotation-based queries. (`PersonRepository.java`)

### Testing Improvements

* Added tests to verify querying by embedded value objects using both repository methods. (`PersonRepositoryTest.java`)
* Extended the `PersonBuilder` to support setting the `ssn` field for test data setup. (`PersonRepositoryTest.java`)